### PR TITLE
Add GitHub sync and configurable LLM enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go test ./...
+      - if: runner.os == 'Windows'
+        run: go build ./...
+      - if: runner.os == 'Linux'
+        run: go vet ./...
+      - if: runner.os == 'Linux'
+        run: go test -race ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 bin/
+plans/

--- a/README.md
+++ b/README.md
@@ -373,10 +373,14 @@ The `llm` section powers `devlog summary create --ai` and `devlog sync --polish`
 | Key | Description |
 |---|---|
 | `enabled` | Must be `true` for LLM features to run. |
-| `provider` | `openrouter` or `openai`. For any other OpenAI-compatible endpoint, set `baseURL` instead. |
+| `provider` | `openrouter`, `openai`, or `deepseek`. For any other OpenAI-compatible endpoint, set `baseURL` instead. |
 | `baseURL` | Optional. Overrides the provider's API base URL (e.g. a local or self-hosted endpoint). |
 | `model` | Model identifier passed to the API. |
 | `apiKeyEnvVar` | Name of the environment variable holding the API key. The key itself is never stored in the config. |
+
+`defaults.language` is included in LLM prompts for both AI summaries and polished sync entries. Use a language tag such as `pt-BR` or `en-US`.
+
+For DeepSeek, set `provider` to `deepseek`, choose a DeepSeek model (for example `deepseek-chat`), and set `apiKeyEnvVar` to the environment variable containing your DeepSeek API key.
 
 The config command interface is planned but not fully implemented yet.
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,28 @@ Setup:
 - Set `github.username` in `~/.devlog/config.json`.
 - Put a GitHub token in the environment variable named by `github.tokenEnvVar` (default `GITHUB_TOKEN`). The token needs the `repo` scope (classic) or Contents read access (fine-grained); authorize it for SSO if your organization requires it.
 
-Re-running `sync` for the same date skips already-imported items, so it is safe to schedule (e.g. a daily cron job).
+Re-running `sync` for the same date skips already-imported items, so it is safe to schedule.
+
+#### Automatic sync
+
+Install a daily job using `launchd` on macOS or the user crontab on Linux:
+
+```bash
+devlog sync schedule --daily-at 23:55
+devlog sync schedule --daily-at 18:00 --polish --env-file ~/.devlog/sync.env
+devlog sync schedule show
+devlog sync schedule remove
+```
+
+Scheduled jobs do not normally inherit an interactive shell's environment. To provide credentials, create a protected environment file:
+
+```bash
+mkdir -p ~/.devlog
+printf 'GITHUB_TOKEN=your-token\nDEEPSEEK_API_KEY=your-key\n' > ~/.devlog/sync.env
+chmod 600 ~/.devlog/sync.env
+```
+
+Pass it with `--env-file` when installing the schedule. The file accepts `KEY=VALUE` lines and is read directly by DevLog; it is never copied into the cron or launchd definition. Job output is appended to `~/.devlog/sync.log`.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Options currently implemented:
 Setup:
 
 - Set `github.username` in `~/.devlog/config.json`.
-- Put a GitHub token in the environment variable named by `github.tokenEnvVar` (default `GITHUB_TOKEN`). The token needs the `repo` scope (classic) or Contents read access (fine-grained); authorize it for SSO if your organization requires it.
+- Put a GitHub token in the environment variable named by `github.tokenEnvVar` (default `GITHUB_TOKEN`). The token needs the `repo` scope (classic) or Contents read and Pull requests read access (fine-grained); authorize it for SSO if your organization requires it.
 
 Re-running `sync` for the same date skips already-imported items, so it is safe to schedule.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ DevLog is intended to be useful both directly from the terminal and through codi
 - Generate a basic Markdown summary for a specific day
 - Show a previously generated summary
 - List previously generated summaries with date-range filters
-- Store all data locally under `~/.devlog/`
+- Store entries as conflict-resistant individual files under `~/.devlog/data/`
+- Synchronize data across machines through a private Git repository
 - Import GitHub activity (commits, authored PRs, PR reviews) as entries with `devlog sync`
 - Generate AI-polished summaries (`--ai`, four style templates) and LLM-rewritten sync descriptions (`--polish`) via any OpenAI-compatible endpoint
 - Report version/build info and self-update from GitHub releases
@@ -57,6 +58,9 @@ Example summary output:
 date: 2026-04-14
 style: concise
 projects: Echo, BitFinance
+aiGenerated: false
+generatedAt: 2026-04-14T18:20:00Z
+deviceId: 62c47f36-08f8-4d43-9f48-a303481b18fc
 ---
 **Echo**
 - Implemented JWT auth middleware
@@ -105,13 +109,20 @@ DevLog stores data locally under:
 ```text
 ~/.devlog/
 ├── config.json
-├── entries/
-│   └── 2026-04-14.json
-└── summaries/
-    └── 2026-04-14.md
+├── device-id
+├── data/
+│   ├── .devlog-version
+│   ├── entries/
+│   │   └── 2026-04-14/
+│   │       └── <entry-id>.json
+│   └── summaries/
+│       └── 2026-04-14.md
+└── backups/
 ```
 
-Entry files are JSON. Summary files are Markdown with YAML frontmatter.
+Entry files are JSON. Summary files are Markdown with YAML frontmatter. Configuration, API credentials, logs, and the local device ID remain outside the synchronized `data/` repository.
+
+Older daily JSON logs are migrated automatically on first use. Run `devlog migrate` explicitly to perform the migration ahead of time. Legacy data is copied to a timestamped directory under `~/.devlog/backups/` before conversion.
 
 ---
 
@@ -126,6 +137,18 @@ devlog init
 ```
 
 Current note: this command uses safe config creation and will not overwrite an existing config file.
+
+---
+
+### `devlog migrate`
+
+Converts legacy daily JSON logs to the conflict-resistant per-entry layout. Normal commands also perform this migration automatically when needed.
+
+```bash
+devlog migrate
+```
+
+The original data is copied to a timestamped backup before the current data-version marker is written.
 
 ---
 
@@ -171,6 +194,7 @@ Options currently implemented:
 | `--date <YYYY-MM-DD>` | Date to sync. Defaults to today. |
 | `--dry-run` | Print what would be imported without writing entries. |
 | `--polish` | Rewrite descriptions with an LLM before saving (requires `llm.enabled` in config). On LLM failure the raw descriptions are kept. |
+| `--remote` | Pull before importing GitHub activity and push the resulting entries afterward. |
 
 Setup:
 
@@ -185,7 +209,7 @@ Install a daily job using `launchd` on macOS or the user crontab on Linux:
 
 ```bash
 devlog sync schedule --daily-at 23:55
-devlog sync schedule --daily-at 18:00 --polish --env-file ~/.devlog/sync.env
+devlog sync schedule --daily-at 18:00 --polish --remote --env-file ~/.devlog/sync.env
 devlog sync schedule show
 devlog sync schedule remove
 ```
@@ -200,12 +224,44 @@ chmod 600 ~/.devlog/sync.env
 
 Pass it with `--env-file` when installing the schedule. The file accepts `KEY=VALUE` lines and is read directly by DevLog; it is never copied into the cron or launchd definition. Job output is appended to `~/.devlog/sync.log`.
 
+With `--remote`, the scheduled job pulls remote DevLog changes, imports GitHub activity, and pushes the combined result. Remote failures return a nonzero exit status and local entries remain available for the next retry.
+
 Examples:
 
 ```bash
 devlog sync
 devlog sync --date 2026-08-05 --dry-run
 ```
+
+---
+
+### `devlog remote`
+
+Synchronizes the local data directory through a private Git repository. DevLog uses the installed `git` executable so existing SSH keys and Git credential helpers continue to work.
+
+```bash
+# First machine
+devlog remote init git@github.com:you/devlog-data.git
+
+# Additional machines use the same command and repository
+devlog remote init git@github.com:you/devlog-data.git
+
+devlog remote status
+devlog remote sync
+devlog remote remove
+```
+
+`remote init` migrates existing data, commits it locally, merges existing remote data, and pushes the result. `remote remove` only disconnects the remote; it does not delete local files or the Git repository on the server.
+
+Remote synchronization:
+
+- merges entries by stable UUID or external `source`;
+- gives GitHub-imported entries deterministic IDs, preventing duplicate imports across machines;
+- retries concurrent non-fast-forward pushes up to three times;
+- keeps the newer summary during a conflict and preserves the other version under `summaries/conflicts/`;
+- operates without an interactive Git credential prompt, making authentication failures visible to scheduled jobs.
+
+Use a private repository because DevLog entries may contain sensitive work information. For unattended scheduling, configure SSH or a Git credential helper that works outside an interactive shell.
 
 ---
 
@@ -383,9 +439,19 @@ Default shape:
     "provider": "openrouter",
     "model": "openai/gpt-oss-120b:free",
     "apiKeyEnvVar": "OPENROUTER_API_KEY"
+  },
+  "remote": {
+    "enabled": false,
+    "url": "",
+    "branch": "main"
+  },
+  "storage": {
+    "path": ""
   }
 }
 ```
+
+An empty `storage.path` uses `~/.devlog/data`. A custom path must be a dedicated data directory and cannot contain `~/.devlog/config.json` or credential files.
 
 ### LLM settings
 
@@ -432,12 +498,6 @@ The following features are planned or partially scaffolded, but should not be tr
 - `devlog config list`
 - `devlog config get <key>`
 - `devlog config set <key> <value>`
-
-### AI-Enhanced Summaries
-
-- output language based on config, e.g. `pt-BR` or `en-US`
-
----
 
 ## Built With
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ DevLog is intended to be useful both directly from the terminal and through codi
 - Show a previously generated summary
 - List previously generated summaries with date-range filters
 - Store all data locally under `~/.devlog/`
+- Import GitHub activity (commits, authored PRs, PR reviews) as entries with `devlog sync`
+- Generate AI-polished summaries (`--ai`, four style templates) and LLM-rewritten sync descriptions (`--polish`) via any OpenAI-compatible endpoint
 - Report version/build info and self-update from GitHub releases
 
 ---
@@ -154,6 +156,38 @@ devlog add "Reviewed checkout API" -p shop --date 2026-04-14
 
 ---
 
+### `devlog sync`
+
+Imports your GitHub activity for a date — commits, pull requests you authored, and pull requests you reviewed — as entries for that day. Private repositories are included as long as the token can access them.
+
+```bash
+devlog sync [options]
+```
+
+Options currently implemented:
+
+| Option | Description |
+|---|---|
+| `--date <YYYY-MM-DD>` | Date to sync. Defaults to today. |
+| `--dry-run` | Print what would be imported without writing entries. |
+| `--polish` | Rewrite descriptions with an LLM before saving (requires `llm.enabled` in config). On LLM failure the raw descriptions are kept. |
+
+Setup:
+
+- Set `github.username` in `~/.devlog/config.json`.
+- Put a GitHub token in the environment variable named by `github.tokenEnvVar` (default `GITHUB_TOKEN`). The token needs the `repo` scope (classic) or Contents read access (fine-grained); authorize it for SSO if your organization requires it.
+
+Re-running `sync` for the same date skips already-imported items, so it is safe to schedule (e.g. a daily cron job).
+
+Examples:
+
+```bash
+devlog sync
+devlog sync --date 2026-08-05 --dry-run
+```
+
+---
+
 ### `devlog list`
 
 Displays entries for today or for a specific date.
@@ -189,15 +223,18 @@ devlog summary create [options]
 
 Options currently implemented:
 
-| Option | Description |
-|---|---|
-| `--date <YYYY-MM-DD>` | Summarize a specific date. Defaults to today. |
+| Option | Short | Description |
+|---|---:|---|
+| `--date <YYYY-MM-DD>` | | Summarize a specific date. Defaults to today. |
+| `--ai` | | Use an LLM to produce a polished narrative (requires `llm.enabled` in config). |
+| `--style <style>` | `-s` | Output style: concise, detailed, formal, impersonal. Only valid with `--ai`; defaults to `defaults.style` from config. |
 
 Examples:
 
 ```bash
 devlog summary create
 devlog summary create --date 2026-04-14
+devlog summary create --ai --style formal
 ```
 
 ---
@@ -316,6 +353,10 @@ Default shape:
     "style": "concise",
     "language": "pt-BR"
   },
+  "github": {
+    "username": "",
+    "tokenEnvVar": "GITHUB_TOKEN"
+  },
   "llm": {
     "enabled": false,
     "provider": "openrouter",
@@ -324,6 +365,18 @@ Default shape:
   }
 }
 ```
+
+### LLM settings
+
+The `llm` section powers `devlog summary create --ai` and `devlog sync --polish`:
+
+| Key | Description |
+|---|---|
+| `enabled` | Must be `true` for LLM features to run. |
+| `provider` | `openrouter` or `openai`. For any other OpenAI-compatible endpoint, set `baseURL` instead. |
+| `baseURL` | Optional. Overrides the provider's API base URL (e.g. a local or self-hosted endpoint). |
+| `model` | Model identifier passed to the API. |
+| `apiKeyEnvVar` | Name of the environment variable holding the API key. The key itself is never stored in the config. |
 
 The config command interface is planned but not fully implemented yet.
 
@@ -346,7 +399,6 @@ The following features are planned or partially scaffolded, but should not be tr
 ### Summaries
 
 - `devlog summary create --week`
-- `devlog summary create --style concise|detailed|formal|impersonal`
 - `devlog summary create --format <template>`
 - summary templates from `~/.devlog/templates/`
 
@@ -358,9 +410,6 @@ The following features are planned or partially scaffolded, but should not be tr
 
 ### AI-Enhanced Summaries
 
-- `devlog summary create --ai`
-- optional LLM narrative polishing
-- support for configured provider/model/API key
 - output language based on config, e.g. `pt-BR` or `en-US`
 
 ---

--- a/cmd/entry/add.go
+++ b/cmd/entry/add.go
@@ -3,8 +3,6 @@ package entry
 import (
 	"devlog/internal/store"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -32,17 +30,10 @@ Examples:
   devlog add "Implemented refresh token rotation" -p echo -t backend,auth
   devlog entry add "Reviewed checkout API" -p shop --date 2026-04-14`,
 		Args: cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			home, err := store.ConfigPath()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			repo, err := store.OpenRepository()
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "%s %s\n", color.RedString("✗"), err)
-				return
-			}
-
-			entriesDir := filepath.Join(home, "entries")
-			if err := os.MkdirAll(entriesDir, 0755); err != nil {
-				fmt.Fprintf(os.Stderr, "%s could not create entries directory: %s\n", color.RedString("✗"), err)
-				return
+				return err
 			}
 
 			var entryDate time.Time
@@ -51,8 +42,7 @@ Examples:
 			} else {
 				entryDate, err = time.Parse("2006-01-02", date)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "%s invalid date format, expected YYYY-MM-DD\n", color.RedString("✗"))
-					return
+					return fmt.Errorf("invalid date format, expected YYYY-MM-DD")
 				}
 			}
 
@@ -76,24 +66,14 @@ Examples:
 				Description: strings.Join(args, " "),
 				Tags:        tags,
 				CreatedAt:   time.Now(),
+				UpdatedAt:   time.Now(),
 			}
-
-			logFile := filepath.Join(entriesDir, entryDate.Format("2006-01-02")+".json")
-
-			dailyLog, err := store.LoadDailyLog(logFile)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "%s %s\n", color.RedString("✗"), err)
-				return
-			}
-			dailyLog.Date = entryDate.Format("2006-01-02")
-			dailyLog.Entries = append(dailyLog.Entries, entry)
-
-			if err := store.SaveDailyLog(logFile, dailyLog); err != nil {
-				fmt.Fprintf(os.Stderr, "%s %s\n", color.RedString("✗"), err)
-				return
+			if _, err := repo.AddEntries(entryDate, []store.Entry{entry}); err != nil {
+				return err
 			}
 
 			fmt.Printf("%s new entry successfully added\n", color.GreenString("✔"))
+			return nil
 		},
 	}
 

--- a/cmd/entry/list.go
+++ b/cmd/entry/list.go
@@ -3,8 +3,6 @@ package entry
 import (
 	"devlog/internal/store"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -38,14 +36,11 @@ Examples:
   devlog list --week
   devlog list --project echo
   devlog entry list --date 2026-04-13`,
-		Run: func(cmd *cobra.Command, args []string) {
-			home, err := store.ConfigPath()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			repo, err := store.OpenRepository()
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "%s %s\n", color.RedString("✗"), err)
-				return
+				return err
 			}
-
-			entriesDir := filepath.Join(home, "entries")
 
 			today := time.Now().Format("2006-01-02")
 			logDate := today
@@ -53,21 +48,16 @@ Examples:
 			if date != "" {
 				parsedDate, err := time.Parse("2006-01-02", date)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "%s invalid date format, expected YYYY-MM-DD\n", color.RedString("✗"))
-					return
+					return fmt.Errorf("invalid date format, expected YYYY-MM-DD")
 				}
 				logDate = parsedDate.Format("2006-01-02")
 			}
 
-			logFile := filepath.Join(entriesDir, logDate+".json")
-
-			dailyLog, err := store.LoadDailyLog(logFile)
+			parsedLogDate, _ := time.Parse("2006-01-02", logDate)
+			entries, err := repo.Entries(parsedLogDate)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "%s %s\n", color.RedString("✗"), err)
-				return
+				return err
 			}
-
-			entries := dailyLog.Entries
 
 			if len(entries) == 0 {
 				label := logDate
@@ -75,7 +65,7 @@ Examples:
 					label = "today"
 				}
 				fmt.Printf("%s No entries for %s\n", dimColor.Sprint("·"), label)
-				return
+				return nil
 			}
 
 			t, _ := time.Parse("2006-01-02", logDate)
@@ -105,6 +95,7 @@ Examples:
 				noun = "entries"
 			}
 			fmt.Printf("  %s\n\n", dimColor.Sprintf("%d %s", len(entries), noun))
+			return nil
 		},
 	}
 

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"fmt"
+
+	"devlog/internal/store"
+
+	"github.com/spf13/cobra"
+)
+
+var migrateCmd = &cobra.Command{
+	Use:   "migrate",
+	Short: "Migrate legacy daily logs to the current data format",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		_, result, err := store.MigrateRepository()
+		if err != nil {
+			return err
+		}
+		if result.AlreadyCurrent {
+			fmt.Println("DevLog data is already using the current format.")
+			return nil
+		}
+		fmt.Printf("Migrated %d entries and %d summaries.\n", result.MigratedEntries, result.MigratedSummaries)
+		if result.BackupPath != "" {
+			fmt.Printf("Backup: %s\n", result.BackupPath)
+		}
+		return nil
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(migrateCmd)
+}

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"devlog/internal/gitremote"
+	"devlog/internal/store"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var remoteCmd = &cobra.Command{
+	Use:   "remote",
+	Short: "Synchronize DevLog data through a private Git repository",
+}
+
+var remoteInitCmd = &cobra.Command{
+	Use:   "init <repository-url>",
+	Short: "Connect local DevLog data to a Git repository",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		branch, _ := cmd.Flags().GetString("branch")
+		repo, err := store.OpenRepository()
+		if err != nil {
+			return err
+		}
+		manager := gitremote.New(repo, args[0], branch)
+		if err := manager.Init(cmd.Context()); err != nil {
+			return err
+		}
+		viper.Set("remote.enabled", true)
+		viper.Set("remote.url", args[0])
+		viper.Set("remote.branch", branch)
+		if err := persistConfig(); err != nil {
+			return fmt.Errorf("remote initialized, but config could not be saved: %w", err)
+		}
+		fmt.Printf("Remote synchronization initialized on branch %s.\n", branch)
+		return nil
+	},
+}
+
+var remoteStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show remote synchronization status",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repo, err := store.OpenRepository()
+		if err != nil {
+			return err
+		}
+		manager := configuredRemote(repo)
+		status, err := manager.Status(cmd.Context())
+		if err != nil {
+			return err
+		}
+		if !status.Initialized {
+			fmt.Println("Remote synchronization is not initialized.")
+			return nil
+		}
+		fmt.Printf("Remote: %s\nBranch: %s\n", status.URL, status.Branch)
+		fmt.Printf("Working tree: %s\n", map[bool]string{true: "modified", false: "clean"}[status.Dirty])
+		fmt.Printf("Ahead: %d, behind: %d\n", status.Ahead, status.Behind)
+		return nil
+	},
+}
+
+var remoteSyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Pull, merge, and push DevLog data",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repo, err := store.OpenRepository()
+		if err != nil {
+			return err
+		}
+		if err := configuredRemote(repo).Sync(cmd.Context()); err != nil {
+			return err
+		}
+		fmt.Println("Remote synchronization complete.")
+		return nil
+	},
+}
+
+var remoteRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Disconnect the remote without deleting local data",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repo, err := store.OpenRepository()
+		if err != nil {
+			return err
+		}
+		if err := configuredRemote(repo).Disconnect(cmd.Context()); err != nil {
+			return err
+		}
+		viper.Set("remote.enabled", false)
+		viper.Set("remote.url", "")
+		if err := persistConfig(); err != nil {
+			return err
+		}
+		fmt.Println("Remote synchronization disconnected. Local data was kept.")
+		return nil
+	},
+}
+
+func configuredRemote(repo *store.Repository) *gitremote.Manager {
+	return gitremote.New(repo, viper.GetString("remote.url"), viper.GetString("remote.branch"))
+}
+
+func syncConfiguredRemote(ctx context.Context, repo *store.Repository) error {
+	if !viper.GetBool("remote.enabled") {
+		return fmt.Errorf("remote synchronization is disabled; run devlog remote init <url>")
+	}
+	return configuredRemote(repo).Sync(ctx)
+}
+
+func persistConfig() error {
+	if path := viper.ConfigFileUsed(); path != "" {
+		return viper.WriteConfig()
+	}
+	root, err := store.ConfigPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(root, 0700); err != nil {
+		return err
+	}
+	return viper.WriteConfigAs(filepath.Join(root, "config.json"))
+}
+
+func init() {
+	RootCmd.AddCommand(remoteCmd)
+	remoteCmd.AddCommand(remoteInitCmd, remoteStatusCmd, remoteSyncCmd, remoteRemoveCmd)
+	remoteInitCmd.Flags().String("branch", "main", "Remote branch used for DevLog data")
+}

--- a/cmd/summary/create.go
+++ b/cmd/summary/create.go
@@ -162,6 +162,10 @@ func generateWithLLM(ctx context.Context, groups []store.ProjectGroup, style str
 	}
 
 	var userPrompt strings.Builder
+	language := viper.GetString("defaults.language")
+	if language != "" {
+		userPrompt.WriteString("Write the output in " + language + ". ")
+	}
 	userPrompt.WriteString("These are my devlog entries for the day, grouped by project. ")
 	userPrompt.WriteString("Turn them into a work summary in the style described. ")
 	userPrompt.WriteString("Output only Markdown: a bold project name as heading per project, followed by bullet points. No title, no preamble, no closing remarks.\n\n")

--- a/cmd/summary/create.go
+++ b/cmd/summary/create.go
@@ -4,7 +4,10 @@ Copyright © 2026 Gustavo Miranda
 package summary
 
 import (
+	"context"
+	"devlog/internal/llm"
 	"devlog/internal/store"
+	"devlog/templates"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +15,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var createCmd = &cobra.Command{
@@ -58,7 +62,25 @@ Examples:
 		}
 
 		grouped := groupByProject(dailyLog.Entries)
+
+		if ai && style == "" {
+			style = viper.GetString("defaults.style")
+		}
+		if style == "" {
+			style = "concise"
+		}
+
 		content := buildContent(grouped)
+		aiGenerated := false
+
+		if ai {
+			aiContent, err := generateWithLLM(cmd.Context(), grouped, style)
+			if err != nil {
+				return fmt.Errorf("%s %s", color.RedString("✗"), err)
+			}
+			content = aiContent
+			aiGenerated = true
+		}
 
 		summariesDir := filepath.Join(home, "summaries")
 		if err := os.MkdirAll(summariesDir, 0755); err != nil {
@@ -66,11 +88,12 @@ Examples:
 		}
 
 		summary := store.Summary{
-			ID:       summaryDate.Format("2006-01-02"),
-			Date:     summaryDate,
-			Projects: grouped,
-			Style:    "concise",
-			Content:  content,
+			ID:          summaryDate.Format("2006-01-02"),
+			Date:        summaryDate,
+			Projects:    grouped,
+			Style:       style,
+			AIGenerated: aiGenerated,
+			Content:     content,
 		}
 
 		summaryFile := filepath.Join(summariesDir, summaryDate.Format("2006-01-02")+".md")
@@ -123,6 +146,39 @@ func buildContent(groups []store.ProjectGroup) string {
 	}
 
 	return strings.TrimRight(sb.String(), "\n")
+}
+
+// generateWithLLM produces a polished narrative summary from the day's
+// entries using the prompt template for the given style.
+func generateWithLLM(ctx context.Context, groups []store.ProjectGroup, style string) (string, error) {
+	template, err := templates.Get(style)
+	if err != nil {
+		return "", err
+	}
+
+	client, err := llm.NewFromConfig()
+	if err != nil {
+		return "", err
+	}
+
+	var userPrompt strings.Builder
+	userPrompt.WriteString("These are my devlog entries for the day, grouped by project. ")
+	userPrompt.WriteString("Turn them into a work summary in the style described. ")
+	userPrompt.WriteString("Output only Markdown: a bold project name as heading per project, followed by bullet points. No title, no preamble, no closing remarks.\n\n")
+	for _, g := range groups {
+		userPrompt.WriteString("Project: " + g.Name + "\n")
+		for _, e := range g.Entries {
+			userPrompt.WriteString("- " + e.Description + "\n")
+		}
+		userPrompt.WriteString("\n")
+	}
+
+	content, err := client.Complete(ctx, template, userPrompt.String())
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(content), nil
 }
 
 func init() {

--- a/cmd/summary/create.go
+++ b/cmd/summary/create.go
@@ -9,8 +9,6 @@ import (
 	"devlog/internal/store"
 	"devlog/templates"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/fatih/color"
@@ -45,23 +43,21 @@ Examples:
 			return err
 		}
 
-		home, err := store.ConfigPath()
+		repo, err := store.OpenRepository()
+		if err != nil {
+			return fmt.Errorf("%s %s", color.RedString("✗"), err)
+		}
+		entries, err := repo.Entries(summaryDate)
 		if err != nil {
 			return fmt.Errorf("%s %s", color.RedString("✗"), err)
 		}
 
-		logFile := filepath.Join(home, "entries", summaryDate.Format("2006-01-02")+".json")
-		dailyLog, err := store.LoadDailyLog(logFile)
-		if err != nil {
-			return fmt.Errorf("%s %s", color.RedString("✗"), err)
-		}
-
-		if len(dailyLog.Entries) == 0 {
+		if len(entries) == 0 {
 			fmt.Printf("  %s\n", color.New(color.FgHiBlack).Sprintf("· No entries found for %s", summaryDate.Format("2006-01-02")))
 			return nil
 		}
 
-		grouped := groupByProject(dailyLog.Entries)
+		grouped := groupByProject(entries)
 
 		if ai && style == "" {
 			style = viper.GetString("defaults.style")
@@ -82,11 +78,6 @@ Examples:
 			aiGenerated = true
 		}
 
-		summariesDir := filepath.Join(home, "summaries")
-		if err := os.MkdirAll(summariesDir, 0755); err != nil {
-			return fmt.Errorf("%s failed to create summaries directory: %w", color.RedString("✗"), err)
-		}
-
 		summary := store.Summary{
 			ID:          summaryDate.Format("2006-01-02"),
 			Date:        summaryDate,
@@ -96,8 +87,7 @@ Examples:
 			Content:     content,
 		}
 
-		summaryFile := filepath.Join(summariesDir, summaryDate.Format("2006-01-02")+".md")
-		if err := store.SaveSummary(summaryFile, summary); err != nil {
+		if err := repo.SaveSummary(summary); err != nil {
 			return fmt.Errorf("%s %s", color.RedString("✗"), err)
 		}
 

--- a/cmd/summary/list.go
+++ b/cmd/summary/list.go
@@ -6,7 +6,6 @@ package summary
 import (
 	"devlog/internal/store"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -55,25 +54,18 @@ Examples:
 			return err
 		}
 
-		home, err := store.ConfigPath()
+		repo, err := store.OpenRepository()
 		if err != nil {
 			return fmt.Errorf("%s %s", color.RedString("✗"), err)
 		}
-		summariesDir := filepath.Join(home, "summaries")
-
-		dirEntries, err := os.ReadDir(summariesDir)
-		if os.IsNotExist(err) {
-			dirEntries = nil
-		} else if err != nil {
+		summaryFiles, err := repo.SummaryFiles()
+		if err != nil {
 			return fmt.Errorf("%s %s", color.RedString("✗"), err)
 		}
 
 		var summaries []store.Summary
-		for _, de := range dirEntries {
-			if de.IsDir() || !strings.HasSuffix(de.Name(), ".md") {
-				continue
-			}
-			name := strings.TrimSuffix(de.Name(), ".md")
+		for _, summaryFile := range summaryFiles {
+			name := strings.TrimSuffix(filepath.Base(summaryFile), ".md")
 			d, err := time.Parse("2006-01-02", name)
 			if err != nil {
 				continue
@@ -83,7 +75,7 @@ Examples:
 				continue
 			}
 
-			summary, err := store.LoadSummary(filepath.Join(summariesDir, de.Name()))
+			summary, err := store.LoadSummary(summaryFile)
 			if err != nil {
 				return fmt.Errorf("%s %s", color.RedString("✗"), err)
 			}

--- a/cmd/summary/show.go
+++ b/cmd/summary/show.go
@@ -6,7 +6,6 @@ package summary
 import (
 	"devlog/internal/store"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -37,13 +36,12 @@ Examples:
 			return err
 		}
 
-		home, err := store.ConfigPath()
+		repo, err := store.OpenRepository()
 		if err != nil {
 			return fmt.Errorf("%s %s\n", color.RedString("✗"), err)
 		}
 
-		summaryPath := filepath.Join(home, "summaries", summaryDate.Format("2006-01-02")+".md")
-		summary, err := store.LoadSummary(summaryPath)
+		summary, err := repo.LoadSummary(summaryDate)
 		if err != nil {
 			return fmt.Errorf("%s %s\n", color.RedString("✗"), err)
 		}
@@ -78,7 +76,7 @@ func getParsedDate(date string) (time.Time, error) {
 	if date == "" {
 		return time.Now(), nil
 	} else {
-		var err error 
+		var err error
 		parsedDate, err := time.Parse("2006-01-02", date)
 		if err != nil {
 			return time.Time{}, fmt.Errorf("invalid date format, expected YYYY-MM-DD\n")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -39,25 +39,33 @@ Examples:
   devlog sync --date 2026-08-05
   devlog sync --polish
   devlog sync --dry-run`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		dateFlag, _ := cmd.Flags().GetString("date")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		polish, _ := cmd.Flags().GetBool("polish")
+		envFile, _ := cmd.Flags().GetString("env-file")
+		if envFile != "" {
+			path, err := absolutePath(envFile)
+			if err != nil {
+				return err
+			}
+			if err := loadEnvFile(path); err != nil {
+				return fmt.Errorf("could not load environment file: %w", err)
+			}
+		}
 
 		syncDate := time.Now()
 		if dateFlag != "" {
 			parsed, err := time.Parse("2006-01-02", dateFlag)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "%s invalid date format, expected YYYY-MM-DD\n", color.RedString("✗"))
-				return
+				return fmt.Errorf("invalid date format, expected YYYY-MM-DD")
 			}
 			syncDate = parsed
 		}
 
 		username := viper.GetString("github.username")
 		if username == "" {
-			fmt.Fprintf(os.Stderr, "%s github.username is not set — add it to ~/.devlog/config.json\n", color.RedString("✗"))
-			return
+			return fmt.Errorf("github.username is not set — add it to ~/.devlog/config.json")
 		}
 
 		tokenEnvVar := viper.GetString("github.tokenEnvVar")
@@ -66,8 +74,7 @@ Examples:
 		}
 		token := os.Getenv(tokenEnvVar)
 		if token == "" {
-			fmt.Fprintf(os.Stderr, "%s no token found — set the %s environment variable\n", color.RedString("✗"), tokenEnvVar)
-			return
+			return fmt.Errorf("no token found — set the %s environment variable", tokenEnvVar)
 		}
 
 		ctx := context.Background()
@@ -76,14 +83,13 @@ Examples:
 		fmt.Printf("Fetching GitHub activity for %s (%s)...\n", username, syncDate.Format("2006-01-02"))
 		activity, err := ghsync.FetchActivity(ctx, client, username, syncDate)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s %s\n", color.RedString("✗"), err)
-			return
+			return err
 		}
 
 		entries := mapActivity(activity)
 		if len(entries) == 0 {
 			fmt.Println("No GitHub activity found for this date.")
-			return
+			return nil
 		}
 
 		if polish {
@@ -100,25 +106,22 @@ Examples:
 				fmt.Printf("%s [%s] %s\n", color.CyanString("•"), e.Project, e.Description)
 			}
 			fmt.Printf("%s %d entries (dry-run, nothing written)\n", color.GreenString("✔"), len(entries))
-			return
+			return nil
 		}
 
 		home, err := store.ConfigPath()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s %s\n", color.RedString("✗"), err)
-			return
+			return err
 		}
 		entriesDir := filepath.Join(home, "entries")
 		if err := os.MkdirAll(entriesDir, 0755); err != nil {
-			fmt.Fprintf(os.Stderr, "%s could not create entries directory: %s\n", color.RedString("✗"), err)
-			return
+			return fmt.Errorf("could not create entries directory: %w", err)
 		}
 
 		logFile := filepath.Join(entriesDir, syncDate.Format("2006-01-02")+".json")
 		dailyLog, err := store.LoadDailyLog(logFile)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s %s\n", color.RedString("✗"), err)
-			return
+			return err
 		}
 		dailyLog.Date = syncDate.Format("2006-01-02")
 
@@ -141,15 +144,15 @@ Examples:
 
 		if added == 0 {
 			fmt.Println("All activity for this date was already imported.")
-			return
+			return nil
 		}
 
 		if err := store.SaveDailyLog(logFile, dailyLog); err != nil {
-			fmt.Fprintf(os.Stderr, "%s %s\n", color.RedString("✗"), err)
-			return
+			return err
 		}
 
 		fmt.Printf("%s %d new entries added\n", color.GreenString("✔"), added)
+		return nil
 	},
 }
 
@@ -254,4 +257,6 @@ func init() {
 	syncCmd.Flags().String("date", "", "Date to sync (YYYY-MM-DD, defaults to today)")
 	syncCmd.Flags().Bool("dry-run", false, "Print what would be imported without writing entries")
 	syncCmd.Flags().Bool("polish", false, "Rewrite descriptions with an LLM (requires llm.enabled in config)")
+	syncCmd.Flags().String("env-file", "", "Load API credentials from a protected KEY=VALUE file")
+	_ = syncCmd.Flags().MarkHidden("env-file")
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -211,6 +211,10 @@ func polishEntries(ctx context.Context, entries []store.Entry) ([]store.Entry, e
 	}
 
 	var userPrompt strings.Builder
+	language := viper.GetString("defaults.language")
+	if language != "" {
+		userPrompt.WriteString("Write every rewritten entry in " + language + ". ")
+	}
 	userPrompt.WriteString("Rewrite each raw git activity line below as a devlog entry in the style described. ")
 	userPrompt.WriteString("Keep the same order and the same number of items. ")
 	userPrompt.WriteString("Respond with a strict JSON array of strings and nothing else — no Markdown fences, no commentary.\n\n")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 	"devlog/templates"
 
 	"github.com/fatih/color"
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -43,6 +41,7 @@ Examples:
 		dateFlag, _ := cmd.Flags().GetString("date")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		polish, _ := cmd.Flags().GetBool("polish")
+		remoteSync, _ := cmd.Flags().GetBool("remote")
 		envFile, _ := cmd.Flags().GetString("env-file")
 		if envFile != "" {
 			path, err := absolutePath(envFile)
@@ -51,6 +50,15 @@ Examples:
 			}
 			if err := loadEnvFile(path); err != nil {
 				return fmt.Errorf("could not load environment file: %w", err)
+			}
+		}
+		repo, err := store.OpenRepository()
+		if err != nil {
+			return err
+		}
+		if remoteSync && !dryRun {
+			if err := syncConfiguredRemote(cmd.Context(), repo); err != nil {
+				return fmt.Errorf("remote pull failed: %w", err)
 			}
 		}
 
@@ -109,49 +117,25 @@ Examples:
 			return nil
 		}
 
-		home, err := store.ConfigPath()
+		addedEntries, err := repo.AddEntries(syncDate, entries)
 		if err != nil {
 			return err
 		}
-		entriesDir := filepath.Join(home, "entries")
-		if err := os.MkdirAll(entriesDir, 0755); err != nil {
-			return fmt.Errorf("could not create entries directory: %w", err)
-		}
-
-		logFile := filepath.Join(entriesDir, syncDate.Format("2006-01-02")+".json")
-		dailyLog, err := store.LoadDailyLog(logFile)
-		if err != nil {
-			return err
-		}
-		dailyLog.Date = syncDate.Format("2006-01-02")
-
-		existing := map[string]bool{}
-		for _, e := range dailyLog.Entries {
-			if e.Source != "" {
-				existing[e.Source] = true
-			}
-		}
-
-		added := 0
-		for _, e := range entries {
-			if existing[e.Source] {
-				continue
-			}
-			dailyLog.Entries = append(dailyLog.Entries, e)
-			added++
+		for _, e := range addedEntries {
 			fmt.Printf("%s [%s] %s\n", color.GreenString("+"), e.Project, e.Description)
 		}
 
-		if added == 0 {
+		if len(addedEntries) == 0 {
 			fmt.Println("All activity for this date was already imported.")
 			return nil
 		}
 
-		if err := store.SaveDailyLog(logFile, dailyLog); err != nil {
-			return err
+		fmt.Printf("%s %d new entries added\n", color.GreenString("✔"), len(addedEntries))
+		if remoteSync {
+			if err := syncConfiguredRemote(cmd.Context(), repo); err != nil {
+				return fmt.Errorf("entries were saved locally, but remote push failed: %w", err)
+			}
 		}
-
-		fmt.Printf("%s %d new entries added\n", color.GreenString("✔"), added)
 		return nil
 	},
 }
@@ -159,15 +143,16 @@ Examples:
 // mapActivity converts fetched GitHub activity into store entries.
 func mapActivity(activity ghsync.Activity) []store.Entry {
 	var entries []store.Entry
-	now := time.Now()
 
 	newEntry := func(project, description, source string, tags ...string) store.Entry {
+		now := time.Now()
 		return store.Entry{
-			Id:          uuid.NewString(),
+			Id:          store.EntryID(source),
 			Project:     project,
 			Description: description,
 			Tags:        tags,
 			CreatedAt:   now,
+			UpdatedAt:   now,
 			Source:      source,
 		}
 	}
@@ -257,6 +242,7 @@ func init() {
 	syncCmd.Flags().String("date", "", "Date to sync (YYYY-MM-DD, defaults to today)")
 	syncCmd.Flags().Bool("dry-run", false, "Print what would be imported without writing entries")
 	syncCmd.Flags().Bool("polish", false, "Rewrite descriptions with an LLM (requires llm.enabled in config)")
+	syncCmd.Flags().Bool("remote", false, "Pull and push the configured DevLog Git remote")
 	syncCmd.Flags().String("env-file", "", "Load API credentials from a protected KEY=VALUE file")
 	_ = syncCmd.Flags().MarkHidden("env-file")
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -1,0 +1,253 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	ghsync "devlog/internal/github"
+	"devlog/internal/llm"
+	"devlog/internal/store"
+	"devlog/templates"
+
+	"github.com/fatih/color"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var syncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Import GitHub activity (commits, PRs, reviews) as entries",
+	Long: `Fetches your GitHub activity for a date — commits, pull requests you
+authored and pull requests you reviewed — and adds them as entries to
+that day's log. Works with private repositories the token can access.
+
+Requires github.username in the config and a token in the environment
+variable named by github.tokenEnvVar (default GITHUB_TOKEN). The token
+needs the "repo" scope (classic) or Contents read access (fine-grained).
+
+Re-running sync for the same date is safe: already-imported items are
+skipped.
+
+Examples:
+  devlog sync
+  devlog sync --date 2026-08-05
+  devlog sync --polish
+  devlog sync --dry-run`,
+	Run: func(cmd *cobra.Command, args []string) {
+		dateFlag, _ := cmd.Flags().GetString("date")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		polish, _ := cmd.Flags().GetBool("polish")
+
+		syncDate := time.Now()
+		if dateFlag != "" {
+			parsed, err := time.Parse("2006-01-02", dateFlag)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%s invalid date format, expected YYYY-MM-DD\n", color.RedString("✗"))
+				return
+			}
+			syncDate = parsed
+		}
+
+		username := viper.GetString("github.username")
+		if username == "" {
+			fmt.Fprintf(os.Stderr, "%s github.username is not set — add it to ~/.devlog/config.json\n", color.RedString("✗"))
+			return
+		}
+
+		tokenEnvVar := viper.GetString("github.tokenEnvVar")
+		if tokenEnvVar == "" {
+			tokenEnvVar = "GITHUB_TOKEN"
+		}
+		token := os.Getenv(tokenEnvVar)
+		if token == "" {
+			fmt.Fprintf(os.Stderr, "%s no token found — set the %s environment variable\n", color.RedString("✗"), tokenEnvVar)
+			return
+		}
+
+		ctx := context.Background()
+		client := ghsync.NewClient(ctx, token)
+
+		fmt.Printf("Fetching GitHub activity for %s (%s)...\n", username, syncDate.Format("2006-01-02"))
+		activity, err := ghsync.FetchActivity(ctx, client, username, syncDate)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s %s\n", color.RedString("✗"), err)
+			return
+		}
+
+		entries := mapActivity(activity)
+		if len(entries) == 0 {
+			fmt.Println("No GitHub activity found for this date.")
+			return
+		}
+
+		if polish {
+			polished, err := polishEntries(cmd.Context(), entries)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%s polish failed, keeping raw descriptions: %s\n", color.YellowString("!"), err)
+			} else {
+				entries = polished
+			}
+		}
+
+		if dryRun {
+			for _, e := range entries {
+				fmt.Printf("%s [%s] %s\n", color.CyanString("•"), e.Project, e.Description)
+			}
+			fmt.Printf("%s %d entries (dry-run, nothing written)\n", color.GreenString("✔"), len(entries))
+			return
+		}
+
+		home, err := store.ConfigPath()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s %s\n", color.RedString("✗"), err)
+			return
+		}
+		entriesDir := filepath.Join(home, "entries")
+		if err := os.MkdirAll(entriesDir, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "%s could not create entries directory: %s\n", color.RedString("✗"), err)
+			return
+		}
+
+		logFile := filepath.Join(entriesDir, syncDate.Format("2006-01-02")+".json")
+		dailyLog, err := store.LoadDailyLog(logFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s %s\n", color.RedString("✗"), err)
+			return
+		}
+		dailyLog.Date = syncDate.Format("2006-01-02")
+
+		existing := map[string]bool{}
+		for _, e := range dailyLog.Entries {
+			if e.Source != "" {
+				existing[e.Source] = true
+			}
+		}
+
+		added := 0
+		for _, e := range entries {
+			if existing[e.Source] {
+				continue
+			}
+			dailyLog.Entries = append(dailyLog.Entries, e)
+			added++
+			fmt.Printf("%s [%s] %s\n", color.GreenString("+"), e.Project, e.Description)
+		}
+
+		if added == 0 {
+			fmt.Println("All activity for this date was already imported.")
+			return
+		}
+
+		if err := store.SaveDailyLog(logFile, dailyLog); err != nil {
+			fmt.Fprintf(os.Stderr, "%s %s\n", color.RedString("✗"), err)
+			return
+		}
+
+		fmt.Printf("%s %d new entries added\n", color.GreenString("✔"), added)
+	},
+}
+
+// mapActivity converts fetched GitHub activity into store entries.
+func mapActivity(activity ghsync.Activity) []store.Entry {
+	var entries []store.Entry
+	now := time.Now()
+
+	newEntry := func(project, description, source string, tags ...string) store.Entry {
+		return store.Entry{
+			Id:          uuid.NewString(),
+			Project:     project,
+			Description: description,
+			Tags:        tags,
+			CreatedAt:   now,
+			Source:      source,
+		}
+	}
+
+	for _, c := range activity.Commits {
+		entries = append(entries, newEntry(shortRepoName(c.Repo), c.Message, "github:commit:"+c.SHA, "github", "commit"))
+	}
+
+	for _, pr := range activity.PRs {
+		action := strings.ToUpper(pr.Action[:1]) + pr.Action[1:]
+		description := fmt.Sprintf("%s PR #%d: %s", action, pr.Number, pr.Title)
+		entries = append(entries, newEntry(shortRepoName(pr.Repo), description, fmt.Sprintf("github:pr:%s#%d", pr.Repo, pr.Number), "github", "pr"))
+	}
+
+	for _, pr := range activity.Reviews {
+		description := fmt.Sprintf("Reviewed PR #%d: %s", pr.Number, pr.Title)
+		entries = append(entries, newEntry(shortRepoName(pr.Repo), description, fmt.Sprintf("github:review:%s#%d", pr.Repo, pr.Number), "github", "review"))
+	}
+
+	return entries
+}
+
+// shortRepoName turns "owner/repo" into "repo" so entries from the same
+// repository share one project name regardless of the item type.
+func shortRepoName(fullName string) string {
+	if i := strings.LastIndex(fullName, "/"); i >= 0 {
+		return fullName[i+1:]
+	}
+	return fullName
+}
+
+// polishEntries rewrites entry descriptions with an LLM using the concise
+// style template. It returns rewritten entries, or an error if the LLM
+// output cannot be mapped back one-to-one onto the input.
+func polishEntries(ctx context.Context, entries []store.Entry) ([]store.Entry, error) {
+	template, err := templates.Get("concise")
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := llm.NewFromConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	var userPrompt strings.Builder
+	userPrompt.WriteString("Rewrite each raw git activity line below as a devlog entry in the style described. ")
+	userPrompt.WriteString("Keep the same order and the same number of items. ")
+	userPrompt.WriteString("Respond with a strict JSON array of strings and nothing else — no Markdown fences, no commentary.\n\n")
+	for i, e := range entries {
+		fmt.Fprintf(&userPrompt, "%d. [%s] %s\n", i+1, e.Project, e.Description)
+	}
+
+	reply, err := client.Complete(ctx, template, userPrompt.String())
+	if err != nil {
+		return nil, err
+	}
+
+	reply = strings.TrimSpace(reply)
+	reply = strings.TrimPrefix(reply, "```json")
+	reply = strings.TrimPrefix(reply, "```")
+	reply = strings.TrimSuffix(reply, "```")
+	reply = strings.TrimSpace(reply)
+
+	var descriptions []string
+	if err := json.Unmarshal([]byte(reply), &descriptions); err != nil {
+		return nil, fmt.Errorf("error parsing polished entries: %w", err)
+	}
+	if len(descriptions) != len(entries) {
+		return nil, fmt.Errorf("LLM returned %d entries, expected %d", len(descriptions), len(entries))
+	}
+
+	for i := range entries {
+		if trimmed := strings.TrimSpace(descriptions[i]); trimmed != "" {
+			entries[i].Description = trimmed
+		}
+	}
+	return entries, nil
+}
+
+func init() {
+	RootCmd.AddCommand(syncCmd)
+	syncCmd.Flags().String("date", "", "Date to sync (YYYY-MM-DD, defaults to today)")
+	syncCmd.Flags().Bool("dry-run", false, "Print what would be imported without writing entries")
+	syncCmd.Flags().Bool("polish", false, "Rewrite descriptions with an LLM (requires llm.enabled in config)")
+}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -27,7 +27,8 @@ that day's log. Works with private repositories the token can access.
 
 Requires github.username in the config and a token in the environment
 variable named by github.tokenEnvVar (default GITHUB_TOKEN). The token
-needs the "repo" scope (classic) or Contents read access (fine-grained).
+needs the "repo" scope (classic) or Contents and Pull requests read access
+(fine-grained).
 
 Re-running sync for the same date is safe: already-imported items are
 skipped.
@@ -85,7 +86,7 @@ Examples:
 			return fmt.Errorf("no token found — set the %s environment variable", tokenEnvVar)
 		}
 
-		ctx := context.Background()
+		ctx := cmd.Context()
 		client := ghsync.NewClient(ctx, token)
 
 		fmt.Printf("Fetching GitHub activity for %s (%s)...\n", username, syncDate.Format("2006-01-02"))
@@ -164,12 +165,12 @@ func mapActivity(activity ghsync.Activity) []store.Entry {
 	for _, pr := range activity.PRs {
 		action := strings.ToUpper(pr.Action[:1]) + pr.Action[1:]
 		description := fmt.Sprintf("%s PR #%d: %s", action, pr.Number, pr.Title)
-		entries = append(entries, newEntry(shortRepoName(pr.Repo), description, fmt.Sprintf("github:pr:%s#%d", pr.Repo, pr.Number), "github", "pr"))
+		entries = append(entries, newEntry(shortRepoName(pr.Repo), description, fmt.Sprintf("github:pr:%s#%d:%s", pr.Repo, pr.Number, pr.Action), "github", "pr"))
 	}
 
 	for _, pr := range activity.Reviews {
 		description := fmt.Sprintf("Reviewed PR #%d: %s", pr.Number, pr.Title)
-		entries = append(entries, newEntry(shortRepoName(pr.Repo), description, fmt.Sprintf("github:review:%s#%d", pr.Repo, pr.Number), "github", "review"))
+		entries = append(entries, newEntry(shortRepoName(pr.Repo), description, fmt.Sprintf("github:review:%s#%d:%s", pr.Repo, pr.Number, pr.OccurredAt.UTC().Format(time.RFC3339Nano)), "github", "review"))
 	}
 
 	return entries

--- a/cmd/sync_schedule.go
+++ b/cmd/sync_schedule.go
@@ -1,0 +1,176 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"devlog/internal/scheduler"
+	"devlog/internal/store"
+
+	"github.com/spf13/cobra"
+)
+
+var syncScheduleCmd = &cobra.Command{
+	Use:   "schedule",
+	Short: "Install a daily automatic sync",
+	Long: `Install a daily sync using launchd on macOS or the user's crontab on Linux.
+
+Scheduled jobs have a minimal environment. Use --env-file to load API keys
+from a file containing KEY=VALUE lines. The file must only be accessible by
+its owner (for example, chmod 600 ~/.devlog/sync.env).`,
+	Example: `  devlog sync schedule --daily-at 23:55
+  devlog sync schedule --daily-at 18:00 --polish --env-file ~/.devlog/sync.env`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dailyAt, _ := cmd.Flags().GetString("daily-at")
+		polish, _ := cmd.Flags().GetBool("polish")
+		envFile, _ := cmd.Flags().GetString("env-file")
+
+		hour, minute, err := scheduler.ParseTime(dailyAt)
+		if err != nil {
+			return err
+		}
+		executable, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("could not locate devlog executable: %w", err)
+		}
+		executable, err = filepath.Abs(executable)
+		if err != nil {
+			return err
+		}
+		if envFile != "" {
+			envFile, err = absolutePath(envFile)
+			if err != nil {
+				return err
+			}
+			if err := validateEnvFile(envFile); err != nil {
+				return err
+			}
+		}
+		home, err := store.ConfigPath()
+		if err != nil {
+			return err
+		}
+		logFile := filepath.Join(home, "sync.log")
+		installedAt, err := scheduler.Install(scheduler.Options{
+			Executable: executable,
+			Hour:       hour,
+			Minute:     minute,
+			Polish:     polish,
+			EnvFile:    envFile,
+			LogFile:    logFile,
+		})
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Automatic sync installed for %02d:%02d daily (%s).\n", hour, minute, installedAt)
+		fmt.Printf("Logs: %s\n", logFile)
+		if envFile == "" {
+			fmt.Println("Note: ensure GITHUB_TOKEN and any LLM API key are available to the scheduled job, or reinstall with --env-file.")
+		}
+		return nil
+	},
+}
+
+var syncScheduleShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show the installed automatic sync definition",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		definition, installed, err := scheduler.Show()
+		if err != nil {
+			return err
+		}
+		if !installed {
+			fmt.Println("No automatic sync is installed.")
+			return nil
+		}
+		fmt.Println(definition)
+		return nil
+	},
+}
+
+var syncScheduleRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove the installed automatic sync",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		removed, err := scheduler.Remove()
+		if err != nil {
+			return err
+		}
+		if !removed {
+			fmt.Println("No automatic sync is installed.")
+			return nil
+		}
+		fmt.Println("Automatic sync removed.")
+		return nil
+	},
+}
+
+func absolutePath(path string) (string, error) {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
+	}
+	return filepath.Abs(path)
+}
+
+func validateEnvFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("could not access environment file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("environment file must be a regular file")
+	}
+	if info.Mode().Perm()&0077 != 0 {
+		return fmt.Errorf("environment file permissions are too open; run chmod 600 %s", path)
+	}
+	return nil
+}
+
+func loadEnvFile(path string) error {
+	if err := validateEnvFile(path); err != nil {
+		return err
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
+		key, value, ok := strings.Cut(line, "=")
+		key = strings.TrimSpace(key)
+		if !ok || key == "" {
+			return fmt.Errorf("invalid environment line: expected KEY=VALUE")
+		}
+		value = strings.TrimSpace(value)
+		if len(value) >= 2 && ((value[0] == '\'' && value[len(value)-1] == '\'') || (value[0] == '"' && value[len(value)-1] == '"')) {
+			value = value[1 : len(value)-1]
+		}
+		if err := os.Setenv(key, value); err != nil {
+			return fmt.Errorf("could not set %s: %w", key, err)
+		}
+	}
+	return scanner.Err()
+}
+
+func init() {
+	syncCmd.AddCommand(syncScheduleCmd)
+	syncScheduleCmd.AddCommand(syncScheduleShowCmd, syncScheduleRemoveCmd)
+	syncScheduleCmd.Flags().String("daily-at", "23:55", "Daily sync time in 24-hour HH:MM format")
+	syncScheduleCmd.Flags().Bool("polish", false, "Rewrite synced descriptions with the configured LLM")
+	syncScheduleCmd.Flags().String("env-file", "", "Protected KEY=VALUE file containing API credentials")
+}

--- a/cmd/sync_schedule.go
+++ b/cmd/sync_schedule.go
@@ -22,10 +22,11 @@ Scheduled jobs have a minimal environment. Use --env-file to load API keys
 from a file containing KEY=VALUE lines. The file must only be accessible by
 its owner (for example, chmod 600 ~/.devlog/sync.env).`,
 	Example: `  devlog sync schedule --daily-at 23:55
-  devlog sync schedule --daily-at 18:00 --polish --env-file ~/.devlog/sync.env`,
+  devlog sync schedule --daily-at 18:00 --polish --remote --env-file ~/.devlog/sync.env`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dailyAt, _ := cmd.Flags().GetString("daily-at")
 		polish, _ := cmd.Flags().GetBool("polish")
+		remote, _ := cmd.Flags().GetBool("remote")
 		envFile, _ := cmd.Flags().GetString("env-file")
 
 		hour, minute, err := scheduler.ParseTime(dailyAt)
@@ -59,6 +60,7 @@ its owner (for example, chmod 600 ~/.devlog/sync.env).`,
 			Hour:       hour,
 			Minute:     minute,
 			Polish:     polish,
+			Remote:     remote,
 			EnvFile:    envFile,
 			LogFile:    logFile,
 		})
@@ -172,5 +174,6 @@ func init() {
 	syncScheduleCmd.AddCommand(syncScheduleShowCmd, syncScheduleRemoveCmd)
 	syncScheduleCmd.Flags().String("daily-at", "23:55", "Daily sync time in 24-hour HH:MM format")
 	syncScheduleCmd.Flags().Bool("polish", false, "Rewrite synced descriptions with the configured LLM")
+	syncScheduleCmd.Flags().Bool("remote", false, "Pull and push the configured Git remote around GitHub import")
 	syncScheduleCmd.Flags().String("env-file", "", "Protected KEY=VALUE file containing API credentials")
 }

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	ghsync "devlog/internal/github"
+)
+
+func TestMapActivityUsesDistinctSourcesForPRActions(t *testing.T) {
+	entries := mapActivity(ghsync.Activity{PRs: []ghsync.PRActivity{
+		{Repo: "acme/widgets", Number: 42, Title: "Ship it", Action: "opened"},
+		{Repo: "acme/widgets", Number: 42, Title: "Ship it", Action: "merged"},
+	}})
+
+	if len(entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(entries))
+	}
+	if entries[0].Source == entries[1].Source {
+		t.Fatalf("opened and merged sources collide: %q", entries[0].Source)
+	}
+}
+
+func TestMapActivityUsesReviewOccurrenceInSource(t *testing.T) {
+	first := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	second := first.Add(24 * time.Hour)
+	entries := mapActivity(ghsync.Activity{Reviews: []ghsync.PRActivity{
+		{Repo: "acme/widgets", Number: 42, Title: "Ship it", Action: "reviewed", OccurredAt: first},
+		{Repo: "acme/widgets", Number: 42, Title: "Ship it", Action: "reviewed", OccurredAt: second},
+	}})
+
+	if len(entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(entries))
+	}
+	if entries[0].Source == entries[1].Source {
+		t.Fatalf("review sources collide: %q", entries[0].Source)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.26.2
 require (
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/fatih/color v1.19.0
+	github.com/google/go-github/v74 v74.0.0
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	go.yaml.in/yaml/v3 v3.0.4
+	golang.org/x/oauth2 v0.34.0
 )
 
 require (
@@ -19,7 +21,6 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-fed/httpsig v1.1.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
-	github.com/google/go-github/v74 v74.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
@@ -37,7 +38,6 @@ require (
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	gitlab.com/gitlab-org/api/client-go v1.9.1 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
-	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/oauth2 v0.34.0
+	golang.org/x/sys v0.42.0
 )
 
 require (
@@ -38,7 +39,6 @@ require (
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	gitlab.com/gitlab-org/api/client-go v1.9.1 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/github/activity.go
+++ b/internal/github/activity.go
@@ -1,8 +1,12 @@
 package github
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -26,21 +30,18 @@ type CommitActivity struct {
 
 // PRActivity is a pull request the user authored or reviewed.
 type PRActivity struct {
-	Number int
-	Repo   string // "owner/repo"
-	Title  string
-	Action string // "opened", "merged" or "reviewed"
-	URL    string
+	Number     int
+	Repo       string // "owner/repo"
+	Title      string
+	Action     string // "opened", "merged" or "reviewed"
+	URL        string
+	OccurredAt time.Time
 }
-
-// searchOpts requests the maximum page size; a single page (100 items) is
-// plenty for one day of activity.
-var searchOpts = &gh.SearchOptions{ListOptions: gh.ListOptions{PerPage: 100}}
 
 // FetchActivity collects the user's commits, authored PRs and PR reviews
 // for the given date using the GitHub search API. Private repositories are
 // included as long as the client's token has access to them.
-func FetchActivity(ctx context.Context, client *gh.Client, username string, date time.Time) (Activity, error) {
+func FetchActivity(ctx context.Context, client *Client, username string, date time.Time) (Activity, error) {
 	if username == "" {
 		return Activity{}, fmt.Errorf("github.username is not set in the devlog config")
 	}
@@ -70,26 +71,42 @@ func FetchActivity(ctx context.Context, client *gh.Client, username string, date
 	return activity, nil
 }
 
-func fetchCommits(ctx context.Context, client *gh.Client, username, date string) ([]CommitActivity, error) {
+func fetchCommits(ctx context.Context, client *Client, username, date string) ([]CommitActivity, error) {
 	query := fmt.Sprintf("author:%s committer-date:%s", username, date)
-	result, _, err := client.Search.Commits(ctx, query, searchOpts)
-	if err != nil {
-		return nil, fmt.Errorf("error searching commits: %w", err)
-	}
-
 	var commits []CommitActivity
-	for _, item := range result.Commits {
-		commits = append(commits, CommitActivity{
-			SHA:     item.GetSHA(),
-			Repo:    item.GetRepository().GetFullName(),
-			Message: firstLine(item.GetCommit().GetMessage()),
-			URL:     item.GetHTMLURL(),
-		})
+	opts := &gh.SearchOptions{ListOptions: gh.ListOptions{PerPage: 100}}
+	expected := 0
+	for {
+		result, response, err := client.REST.Search.Commits(ctx, query, opts)
+		if err != nil {
+			return nil, fmt.Errorf("error searching commits: %w", err)
+		}
+		if result.GetIncompleteResults() {
+			return nil, fmt.Errorf("error searching commits: GitHub returned incomplete results")
+		}
+		if expected == 0 {
+			expected = result.GetTotal()
+		}
+		for _, item := range result.Commits {
+			commits = append(commits, CommitActivity{
+				SHA:     item.GetSHA(),
+				Repo:    item.GetRepository().GetFullName(),
+				Message: firstLine(item.GetCommit().GetMessage()),
+				URL:     item.GetHTMLURL(),
+			})
+		}
+		if response.NextPage == 0 {
+			break
+		}
+		opts.Page = response.NextPage
+	}
+	if len(commits) < expected {
+		return nil, fmt.Errorf("error searching commits: GitHub returned %d of %d results", len(commits), expected)
 	}
 	return commits, nil
 }
 
-func fetchAuthoredPRs(ctx context.Context, client *gh.Client, username, date string) ([]PRActivity, error) {
+func fetchAuthoredPRs(ctx context.Context, client *Client, username, date string) ([]PRActivity, error) {
 	queries := []struct {
 		q      string
 		action string
@@ -101,33 +118,156 @@ func fetchAuthoredPRs(ctx context.Context, client *gh.Client, username, date str
 	var prs []PRActivity
 	seen := map[string]bool{}
 	for _, query := range queries {
-		result, _, err := client.Search.Issues(ctx, query.q, searchOpts)
-		if err != nil {
-			return nil, fmt.Errorf("error searching pull requests: %w", err)
-		}
-		for _, issue := range result.Issues {
-			pr := prFromIssue(issue, query.action)
-			key := fmt.Sprintf("%s#%d", pr.Repo, pr.Number)
-			if seen[key] {
-				continue
+		opts := &gh.SearchOptions{ListOptions: gh.ListOptions{PerPage: 100}}
+		collected := 0
+		expected := 0
+		for {
+			result, response, err := client.REST.Search.Issues(ctx, query.q, opts)
+			if err != nil {
+				return nil, fmt.Errorf("error searching pull requests: %w", err)
 			}
-			seen[key] = true
-			prs = append(prs, pr)
+			if result.GetIncompleteResults() {
+				return nil, fmt.Errorf("error searching pull requests: GitHub returned incomplete results")
+			}
+			if expected == 0 {
+				expected = result.GetTotal()
+			}
+			collected += len(result.Issues)
+			for _, issue := range result.Issues {
+				pr := prFromIssue(issue, query.action)
+				key := fmt.Sprintf("%s#%d:%s", pr.Repo, pr.Number, pr.Action)
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				prs = append(prs, pr)
+			}
+			if response.NextPage == 0 {
+				break
+			}
+			opts.Page = response.NextPage
+		}
+		if collected < expected {
+			return nil, fmt.Errorf("error searching pull requests: GitHub returned %d of %d results", collected, expected)
 		}
 	}
 	return prs, nil
 }
 
-func fetchReviews(ctx context.Context, client *gh.Client, username, date string) ([]PRActivity, error) {
-	query := fmt.Sprintf("type:pr reviewed-by:%s -author:%s updated:%s", username, username, date)
-	result, _, err := client.Search.Issues(ctx, query, searchOpts)
+func fetchReviews(ctx context.Context, client *Client, username, date string) ([]PRActivity, error) {
+	parsedDate, err := time.Parse("2006-01-02", date)
 	if err != nil {
-		return nil, fmt.Errorf("error searching reviewed pull requests: %w", err)
+		return nil, fmt.Errorf("error preparing review search: %w", err)
+	}
+	from := parsedDate.UTC()
+	to := from.AddDate(0, 0, 1)
+	query := `query($login: String!, $from: DateTime!, $to: DateTime!, $after: String) {
+  user(login: $login) {
+    contributionsCollection(from: $from, to: $to) {
+      pullRequestReviewContributions(first: 100, after: $after) {
+        nodes {
+          occurredAt
+          pullRequest { number title url repository { nameWithOwner } }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`
+	type graphQLError struct {
+		Message string `json:"message"`
+	}
+	type contribution struct {
+		OccurredAt  time.Time `json:"occurredAt"`
+		PullRequest struct {
+			Number     int    `json:"number"`
+			Title      string `json:"title"`
+			URL        string `json:"url"`
+			Repository struct {
+				NameWithOwner string `json:"nameWithOwner"`
+			} `json:"repository"`
+		} `json:"pullRequest"`
+	}
+	type graphQLResponse struct {
+		Data struct {
+			User *struct {
+				ContributionsCollection struct {
+					PullRequestReviewContributions struct {
+						Nodes    []contribution `json:"nodes"`
+						PageInfo struct {
+							HasNextPage bool   `json:"hasNextPage"`
+							EndCursor   string `json:"endCursor"`
+						} `json:"pageInfo"`
+					} `json:"pullRequestReviewContributions"`
+				} `json:"contributionsCollection"`
+			} `json:"user"`
+		} `json:"data"`
+		Errors []graphQLError `json:"errors"`
 	}
 
 	var reviews []PRActivity
-	for _, issue := range result.Issues {
-		reviews = append(reviews, prFromIssue(issue, "reviewed"))
+	var after any
+	for {
+		payload, err := json.Marshal(map[string]any{
+			"query": query,
+			"variables": map[string]any{
+				"login": username,
+				"from":  from.Format(time.RFC3339),
+				"to":    to.Format(time.RFC3339),
+				"after": after,
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error encoding review query: %w", err)
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, client.GraphQLURL, bytes.NewReader(payload))
+		if err != nil {
+			return nil, fmt.Errorf("error building review query: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		response, err := client.HTTP.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("error searching reviewed pull requests: %w", err)
+		}
+		body, readErr := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+		response.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("error reading review search response: %w", readErr)
+		}
+		if response.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("error searching reviewed pull requests: GitHub GraphQL returned status %d", response.StatusCode)
+		}
+		var result graphQLResponse
+		if err := json.Unmarshal(body, &result); err != nil {
+			return nil, fmt.Errorf("error parsing review search response: %w", err)
+		}
+		if len(result.Errors) > 0 {
+			return nil, fmt.Errorf("error searching reviewed pull requests: %s", result.Errors[0].Message)
+		}
+		if result.Data.User == nil {
+			return nil, fmt.Errorf("error searching reviewed pull requests: GitHub user %q was not found", username)
+		}
+		connection := result.Data.User.ContributionsCollection.PullRequestReviewContributions
+		for _, item := range connection.Nodes {
+			if item.OccurredAt.Before(from) || !item.OccurredAt.Before(to) {
+				continue
+			}
+			reviews = append(reviews, PRActivity{
+				Number:     item.PullRequest.Number,
+				Repo:       item.PullRequest.Repository.NameWithOwner,
+				Title:      item.PullRequest.Title,
+				Action:     "reviewed",
+				URL:        item.PullRequest.URL,
+				OccurredAt: item.OccurredAt,
+			})
+		}
+		if !connection.PageInfo.HasNextPage {
+			break
+		}
+		if connection.PageInfo.EndCursor == "" {
+			return nil, fmt.Errorf("error searching reviewed pull requests: GitHub omitted the next review cursor")
+		}
+		after = connection.PageInfo.EndCursor
 	}
 	return reviews, nil
 }

--- a/internal/github/activity.go
+++ b/internal/github/activity.go
@@ -1,0 +1,156 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	gh "github.com/google/go-github/v74/github"
+)
+
+// Activity holds everything a user did on GitHub on a given date.
+type Activity struct {
+	Commits []CommitActivity
+	PRs     []PRActivity
+	Reviews []PRActivity
+}
+
+// CommitActivity is a single authored commit with its change stats.
+type CommitActivity struct {
+	SHA     string
+	Repo    string // "owner/repo"
+	Message string // first line of the commit message
+	URL     string
+}
+
+// PRActivity is a pull request the user authored or reviewed.
+type PRActivity struct {
+	Number int
+	Repo   string // "owner/repo"
+	Title  string
+	Action string // "opened", "merged" or "reviewed"
+	URL    string
+}
+
+// searchOpts requests the maximum page size; a single page (100 items) is
+// plenty for one day of activity.
+var searchOpts = &gh.SearchOptions{ListOptions: gh.ListOptions{PerPage: 100}}
+
+// FetchActivity collects the user's commits, authored PRs and PR reviews
+// for the given date using the GitHub search API. Private repositories are
+// included as long as the client's token has access to them.
+func FetchActivity(ctx context.Context, client *gh.Client, username string, date time.Time) (Activity, error) {
+	if username == "" {
+		return Activity{}, fmt.Errorf("github.username is not set in the devlog config")
+	}
+
+	d := date.Format("2006-01-02")
+
+	var activity Activity
+
+	commits, err := fetchCommits(ctx, client, username, d)
+	if err != nil {
+		return activity, err
+	}
+	activity.Commits = commits
+
+	prs, err := fetchAuthoredPRs(ctx, client, username, d)
+	if err != nil {
+		return activity, err
+	}
+	activity.PRs = prs
+
+	reviews, err := fetchReviews(ctx, client, username, d)
+	if err != nil {
+		return activity, err
+	}
+	activity.Reviews = reviews
+
+	return activity, nil
+}
+
+func fetchCommits(ctx context.Context, client *gh.Client, username, date string) ([]CommitActivity, error) {
+	query := fmt.Sprintf("author:%s committer-date:%s", username, date)
+	result, _, err := client.Search.Commits(ctx, query, searchOpts)
+	if err != nil {
+		return nil, fmt.Errorf("error searching commits: %w", err)
+	}
+
+	var commits []CommitActivity
+	for _, item := range result.Commits {
+		commits = append(commits, CommitActivity{
+			SHA:     item.GetSHA(),
+			Repo:    item.GetRepository().GetFullName(),
+			Message: firstLine(item.GetCommit().GetMessage()),
+			URL:     item.GetHTMLURL(),
+		})
+	}
+	return commits, nil
+}
+
+func fetchAuthoredPRs(ctx context.Context, client *gh.Client, username, date string) ([]PRActivity, error) {
+	queries := []struct {
+		q      string
+		action string
+	}{
+		{fmt.Sprintf("type:pr author:%s created:%s", username, date), "opened"},
+		{fmt.Sprintf("type:pr author:%s merged:%s", username, date), "merged"},
+	}
+
+	var prs []PRActivity
+	seen := map[string]bool{}
+	for _, query := range queries {
+		result, _, err := client.Search.Issues(ctx, query.q, searchOpts)
+		if err != nil {
+			return nil, fmt.Errorf("error searching pull requests: %w", err)
+		}
+		for _, issue := range result.Issues {
+			pr := prFromIssue(issue, query.action)
+			key := fmt.Sprintf("%s#%d", pr.Repo, pr.Number)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			prs = append(prs, pr)
+		}
+	}
+	return prs, nil
+}
+
+func fetchReviews(ctx context.Context, client *gh.Client, username, date string) ([]PRActivity, error) {
+	query := fmt.Sprintf("type:pr reviewed-by:%s -author:%s updated:%s", username, username, date)
+	result, _, err := client.Search.Issues(ctx, query, searchOpts)
+	if err != nil {
+		return nil, fmt.Errorf("error searching reviewed pull requests: %w", err)
+	}
+
+	var reviews []PRActivity
+	for _, issue := range result.Issues {
+		reviews = append(reviews, prFromIssue(issue, "reviewed"))
+	}
+	return reviews, nil
+}
+
+func prFromIssue(issue *gh.Issue, action string) PRActivity {
+	repo := ""
+	if u := issue.GetRepositoryURL(); u != "" {
+		if i := strings.LastIndex(u, "/repos/"); i >= 0 {
+			repo = u[i+len("/repos/"):]
+		}
+	}
+	return PRActivity{
+		Number: issue.GetNumber(),
+		Repo:   repo,
+		Title:  issue.GetTitle(),
+		Action: action,
+		URL:    issue.GetHTMLURL(),
+	}
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/internal/github/activity_test.go
+++ b/internal/github/activity_test.go
@@ -1,0 +1,251 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v74/github"
+)
+
+func TestFetchActivityCollectsEveryCommitPage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/commits":
+			page := r.URL.Query().Get("page")
+			if page == "" {
+				w.Header().Set("Link", fmt.Sprintf(`<%s/search/commits?page=2>; rel="next"`, serverURL(r)))
+				_, _ = w.Write([]byte(commitSearchPage("first")))
+				return
+			}
+			_, _ = w.Write([]byte(commitSearchPage("second")))
+		case "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count":0,"incomplete_results":false,"items":[]}`))
+		case "/graphql":
+			_, _ = w.Write([]byte(emptyReviewContributionPage()))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := gh.NewClient(server.Client())
+	baseURL, _ := url.Parse(server.URL + "/")
+	client.BaseURL = baseURL
+	activity, err := FetchActivity(context.Background(), &Client{REST: client, HTTP: server.Client(), GraphQLURL: server.URL + "/graphql"}, "octocat", time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(activity.Commits) != 2 || activity.Commits[0].SHA != "first" || activity.Commits[1].SHA != "second" {
+		t.Fatalf("commits = %+v, want both pages", activity.Commits)
+	}
+}
+
+func TestFetchActivityRejectsIncompleteSearchResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/search/commits" {
+			_, _ = w.Write([]byte(`{"total_count":1,"incomplete_results":true,"items":[]}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := gh.NewClient(server.Client())
+	baseURL, _ := url.Parse(server.URL + "/")
+	client.BaseURL = baseURL
+	_, err := FetchActivity(context.Background(), &Client{REST: client, HTTP: server.Client(), GraphQLURL: server.URL + "/graphql"}, "octocat", time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC))
+	if err == nil || !strings.Contains(err.Error(), "incomplete") {
+		t.Fatalf("error = %v, want incomplete-results failure", err)
+	}
+}
+
+func TestFetchActivityRejectsCappedSearchResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/search/commits" {
+			_, _ = w.Write([]byte(commitSearchPage("only-result")))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := gh.NewClient(server.Client())
+	baseURL, _ := url.Parse(server.URL + "/")
+	client.BaseURL = baseURL
+	_, err := FetchActivity(context.Background(), &Client{REST: client, HTTP: server.Client(), GraphQLURL: server.URL + "/graphql"}, "octocat", time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC))
+	if err == nil || !strings.Contains(err.Error(), "1 of 2") {
+		t.Fatalf("error = %v, want capped-results failure", err)
+	}
+}
+
+func TestFetchActivityUsesDateBoundedPaginatedReviewContributions(t *testing.T) {
+	var graphqlRequests int
+	var variables []map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/commits", "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count":0,"incomplete_results":false,"items":[]}`))
+		case "/graphql":
+			graphqlRequests++
+			var request struct {
+				Variables map[string]any `json:"variables"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode GraphQL request: %v", err)
+			}
+			variables = append(variables, request.Variables)
+			if graphqlRequests == 1 {
+				_, _ = w.Write([]byte(reviewContributionPage("2026-08-08T10:30:00Z", true, "next")))
+				return
+			}
+			_, _ = w.Write([]byte(reviewContributionPage("2026-08-08T18:45:00Z", false, "")))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	rest := gh.NewClient(server.Client())
+	baseURL, _ := url.Parse(server.URL + "/")
+	rest.BaseURL = baseURL
+	activity, err := FetchActivity(context.Background(), &Client{REST: rest, HTTP: server.Client(), GraphQLURL: server.URL + "/graphql"}, "octocat", time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if graphqlRequests != 2 {
+		t.Fatalf("GraphQL requests = %d, want 2", graphqlRequests)
+	}
+	if variables[0]["from"] != "2026-08-08T00:00:00Z" || variables[0]["to"] != "2026-08-09T00:00:00Z" {
+		t.Fatalf("date variables = %+v", variables[0])
+	}
+	if variables[0]["after"] != nil || variables[1]["after"] != "next" {
+		t.Fatalf("cursor variables = %+v", variables)
+	}
+	if len(activity.Reviews) != 2 {
+		t.Fatalf("reviews = %+v, want both pages", activity.Reviews)
+	}
+	if got := activity.Reviews[0].OccurredAt.Format(time.RFC3339); got != "2026-08-08T10:30:00Z" {
+		t.Fatalf("occurredAt = %s", got)
+	}
+}
+
+func TestFetchActivityKeepsOpenedAndMergedEventsForSamePR(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/commits":
+			_, _ = w.Write([]byte(`{"total_count":0,"incomplete_results":false,"items":[]}`))
+		case "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count":1,"incomplete_results":false,"items":[{"number":42,"title":"Ship it","repository_url":"https://api.github.com/repos/acme/widgets","html_url":"https://github.com/acme/widgets/pull/42"}]}`))
+		case "/graphql":
+			_, _ = w.Write([]byte(emptyReviewContributionPage()))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	rest := gh.NewClient(server.Client())
+	baseURL, _ := url.Parse(server.URL + "/")
+	rest.BaseURL = baseURL
+	activity, err := FetchActivity(context.Background(), &Client{REST: rest, HTTP: server.Client(), GraphQLURL: server.URL + "/graphql"}, "octocat", time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(activity.PRs) != 2 || activity.PRs[0].Action != "opened" || activity.PRs[1].Action != "merged" {
+		t.Fatalf("pull requests = %+v, want opened and merged events", activity.PRs)
+	}
+}
+
+func TestFetchActivityReportsGraphQLErrors(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "API error", body: `{"errors":[{"message":"review access denied"}]}`, want: "review access denied"},
+		{name: "malformed response", body: `{`, want: "parsing review search response"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/search/commits", "/search/issues":
+					_, _ = w.Write([]byte(`{"total_count":0,"incomplete_results":false,"items":[]}`))
+				case "/graphql":
+					_, _ = w.Write([]byte(test.body))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			rest := gh.NewClient(server.Client())
+			baseURL, _ := url.Parse(server.URL + "/")
+			rest.BaseURL = baseURL
+			_, err := FetchActivity(context.Background(), &Client{REST: rest, HTTP: server.Client(), GraphQLURL: server.URL + "/graphql"}, "octocat", time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestFetchActivityCancelsGraphQLRequest(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/commits", "/search/issues":
+			_, _ = w.Write([]byte(`{"total_count":0,"incomplete_results":false,"items":[]}`))
+		case "/graphql":
+			close(started)
+			select {
+			case <-r.Context().Done():
+			case <-release:
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	rest := gh.NewClient(server.Client())
+	baseURL, _ := url.Parse(server.URL + "/")
+	rest.BaseURL = baseURL
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := FetchActivity(ctx, &Client{REST: rest, HTTP: server.Client(), GraphQLURL: server.URL + "/graphql"}, "octocat", time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC))
+		result <- err
+	}()
+	<-started
+	cancel()
+	err := <-result
+	close(release)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context cancellation", err)
+	}
+}
+
+func commitSearchPage(sha string) string {
+	return fmt.Sprintf(`{"total_count":2,"incomplete_results":false,"items":[{"sha":%q,"repository":{"full_name":"acme/widgets"},"commit":{"message":%q},"html_url":"https://github.com/acme/widgets/commit/%s"}]}`, sha, sha, sha)
+}
+
+func serverURL(r *http.Request) string {
+	return "http://" + r.Host
+}
+
+func reviewContributionPage(occurredAt string, hasNext bool, cursor string) string {
+	return fmt.Sprintf(`{"data":{"user":{"contributionsCollection":{"pullRequestReviewContributions":{"nodes":[{"occurredAt":%q,"pullRequest":{"number":42,"title":"Ship it","url":"https://github.com/acme/widgets/pull/42","repository":{"nameWithOwner":"acme/widgets"}}}],"pageInfo":{"hasNextPage":%t,"endCursor":%q}}}}}}`, occurredAt, hasNext, cursor)
+}
+
+func emptyReviewContributionPage() string {
+	return `{"data":{"user":{"contributionsCollection":{"pullRequestReviewContributions":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -4,14 +4,25 @@ package github
 
 import (
 	"context"
+	"net/http"
 
 	gh "github.com/google/go-github/v74/github"
 	"golang.org/x/oauth2"
 )
 
+const defaultGraphQLURL = "https://api.github.com/graphql"
+
+// Client contains the authenticated transports used by GitHub's REST and
+// GraphQL APIs.
+type Client struct {
+	REST       *gh.Client
+	HTTP       *http.Client
+	GraphQLURL string
+}
+
 // NewClient returns an authenticated GitHub API client.
-func NewClient(ctx context.Context, token string) *gh.Client {
+func NewClient(ctx context.Context, token string) *Client {
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	tc := oauth2.NewClient(ctx, ts)
-	return gh.NewClient(tc)
+	return &Client{REST: gh.NewClient(tc), HTTP: tc, GraphQLURL: defaultGraphQLURL}
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,0 +1,17 @@
+// Package github fetches a user's GitHub activity (commits, pull requests,
+// reviews) for a given date, across all repositories the token can see.
+package github
+
+import (
+	"context"
+
+	gh "github.com/google/go-github/v74/github"
+	"golang.org/x/oauth2"
+)
+
+// NewClient returns an authenticated GitHub API client.
+func NewClient(ctx context.Context, token string) *gh.Client {
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	tc := oauth2.NewClient(ctx, ts)
+	return gh.NewClient(tc)
+}

--- a/internal/gitremote/gitremote.go
+++ b/internal/gitremote/gitremote.go
@@ -115,7 +115,7 @@ func (m *Manager) syncLocked(ctx context.Context) error {
 }
 
 func (m *Manager) mergeRemote(ctx context.Context) error {
-	_, err := m.git(ctx, "merge", "--no-edit", "--allow-unrelated-histories", "origin/"+m.Branch)
+	_, err := m.git(ctx, "-c", "user.name=DevLog", "-c", "user.email=devlog@local", "merge", "--no-edit", "--allow-unrelated-histories", "origin/"+m.Branch)
 	if err == nil {
 		if err := m.reconcileDuplicateSources(); err != nil {
 			return err

--- a/internal/gitremote/gitremote.go
+++ b/internal/gitremote/gitremote.go
@@ -1,0 +1,419 @@
+// Package gitremote synchronizes a DevLog data repository through Git.
+package gitremote
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"devlog/internal/store"
+)
+
+const maxPushAttempts = 3
+
+type Manager struct {
+	Repository *store.Repository
+	URL        string
+	Branch     string
+}
+
+type Status struct {
+	Initialized bool
+	URL         string
+	Branch      string
+	Dirty       bool
+	Ahead       int
+	Behind      int
+}
+
+func New(repository *store.Repository, url, branch string) *Manager {
+	if branch == "" {
+		branch = "main"
+	}
+	return &Manager{Repository: repository, URL: url, Branch: branch}
+}
+
+func (m *Manager) Init(ctx context.Context) error {
+	if m.URL == "" {
+		return fmt.Errorf("remote repository URL is required")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		return fmt.Errorf("git executable was not found")
+	}
+	unlock, err := m.Repository.Lock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	if !m.isGitRepository() {
+		if _, err := m.git(ctx, "init", "-b", m.Branch); err != nil {
+			if _, fallbackErr := m.git(ctx, "init"); fallbackErr != nil {
+				return err
+			}
+			if _, err := m.git(ctx, "checkout", "-b", m.Branch); err != nil {
+				return err
+			}
+		}
+	}
+	if _, err := m.git(ctx, "remote", "get-url", "origin"); err == nil {
+		if _, err := m.git(ctx, "remote", "set-url", "origin", m.URL); err != nil {
+			return err
+		}
+	} else if _, err := m.git(ctx, "remote", "add", "origin", m.URL); err != nil {
+		return err
+	}
+	if err := m.commit(ctx, "Initialize DevLog data repository"); err != nil {
+		return err
+	}
+	return m.syncLocked(ctx)
+}
+
+func (m *Manager) Sync(ctx context.Context) error {
+	if !m.isGitRepository() || !m.hasOrigin(ctx) {
+		return fmt.Errorf("remote sync is not initialized; run devlog remote init <url>")
+	}
+	unlock, err := m.Repository.Lock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return m.syncLocked(ctx)
+}
+
+func (m *Manager) syncLocked(ctx context.Context) error {
+	if err := m.commit(ctx, "Sync local DevLog changes"); err != nil {
+		return err
+	}
+	for attempt := 1; attempt <= maxPushAttempts; attempt++ {
+		exists, err := m.remoteBranchExists(ctx)
+		if err != nil {
+			return err
+		}
+		if exists {
+			if _, err := m.git(ctx, "fetch", "origin", m.Branch); err != nil {
+				return err
+			}
+			if err := m.mergeRemote(ctx); err != nil {
+				return err
+			}
+		}
+		if _, err := m.git(ctx, "push", "-u", "origin", "HEAD:"+m.Branch); err == nil {
+			return nil
+		} else if attempt == maxPushAttempts {
+			return fmt.Errorf("could not push DevLog data after %d attempts: %w", maxPushAttempts, err)
+		}
+	}
+	return nil
+}
+
+func (m *Manager) mergeRemote(ctx context.Context) error {
+	_, err := m.git(ctx, "merge", "--no-edit", "--allow-unrelated-histories", "origin/"+m.Branch)
+	if err == nil {
+		if err := m.reconcileDuplicateSources(); err != nil {
+			return err
+		}
+		return m.commit(ctx, "Reconcile remote DevLog changes")
+	}
+	conflicts, conflictErr := m.git(ctx, "diff", "--name-only", "--diff-filter=U", "-z")
+	if conflictErr != nil || len(conflicts) == 0 {
+		return err
+	}
+	for _, path := range bytes.Split(bytes.TrimRight(conflicts, "\x00"), []byte{0}) {
+		if len(path) == 0 {
+			continue
+		}
+		if err := m.resolveConflict(ctx, string(path)); err != nil {
+			_, _ = m.git(ctx, "merge", "--abort")
+			return err
+		}
+	}
+	if err := m.reconcileDuplicateSources(); err != nil {
+		return err
+	}
+	if _, err := m.git(ctx, "add", "-A"); err != nil {
+		return err
+	}
+	return m.commit(ctx, "Merge remote DevLog changes")
+}
+
+func (m *Manager) resolveConflict(ctx context.Context, path string) error {
+	ours, oursErr := m.stageFile(ctx, 2, path)
+	theirs, theirsErr := m.stageFile(ctx, 3, path)
+	if oursErr != nil && theirsErr != nil {
+		return fmt.Errorf("could not read either side of conflict %s", path)
+	}
+
+	var winner []byte
+	switch {
+	case strings.HasPrefix(path, "entries/") && strings.HasSuffix(path, ".json"):
+		winner = newerEntry(ours, theirs)
+	case strings.HasPrefix(path, "summaries/") && strings.HasSuffix(path, ".md"):
+		var loser []byte
+		winner, loser = newerSummary(ours, theirs)
+		if len(loser) > 0 && !bytes.Equal(winner, loser) {
+			if err := m.preserveSummaryConflict(path, loser); err != nil {
+				return err
+			}
+		}
+	case path == ".devlog-version" || path == ".gitignore":
+		winner = ours
+		if len(winner) == 0 {
+			winner = theirs
+		}
+	default:
+		return fmt.Errorf("unresolved Git conflict in unexpected file %s", path)
+	}
+	if len(winner) == 0 {
+		if err := os.Remove(filepath.Join(m.Repository.Root, path)); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	} else if err := atomicWrite(filepath.Join(m.Repository.Root, path), winner); err != nil {
+		return err
+	}
+	_, err := m.git(ctx, "add", "--", path)
+	return err
+}
+
+func (m *Manager) stageFile(ctx context.Context, stage int, path string) ([]byte, error) {
+	data, err := m.git(ctx, "show", fmt.Sprintf(":%d:%s", stage, path))
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func newerEntry(a, b []byte) []byte {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	var first, second store.Entry
+	if json.Unmarshal(a, &first) != nil {
+		return b
+	}
+	if json.Unmarshal(b, &second) != nil {
+		return a
+	}
+	firstTime := first.UpdatedAt
+	if firstTime.IsZero() {
+		firstTime = first.CreatedAt
+	}
+	secondTime := second.UpdatedAt
+	if secondTime.IsZero() {
+		secondTime = second.CreatedAt
+	}
+	if secondTime.After(firstTime) || secondTime.Equal(firstTime) && bytes.Compare(b, a) > 0 {
+		return b
+	}
+	return a
+}
+
+func newerSummary(a, b []byte) ([]byte, []byte) {
+	if len(a) == 0 {
+		return b, nil
+	}
+	if len(b) == 0 {
+		return a, nil
+	}
+	first, firstErr := store.ParseSummary(a)
+	second, secondErr := store.ParseSummary(b)
+	if firstErr != nil {
+		return b, a
+	}
+	if secondErr != nil {
+		return a, b
+	}
+	if second.GeneratedAt.After(first.GeneratedAt) || second.GeneratedAt.Equal(first.GeneratedAt) && bytes.Compare(b, a) > 0 {
+		return b, a
+	}
+	return a, b
+}
+
+func (m *Manager) preserveSummaryConflict(path string, content []byte) error {
+	summary, _ := store.ParseSummary(content)
+	device := summary.DeviceID
+	if device == "" {
+		device = "unknown"
+	}
+	device = strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' {
+			return r
+		}
+		return '-'
+	}, device)
+	name := strings.TrimSuffix(filepath.Base(path), ".md")
+	conflictPath := filepath.Join(m.Repository.Root, "summaries", "conflicts", fmt.Sprintf("%s.%s.%d.md", name, device, time.Now().UTC().UnixNano()))
+	return atomicWrite(conflictPath, content)
+}
+
+func (m *Manager) reconcileDuplicateSources() error {
+	root := filepath.Join(m.Repository.Root, "entries")
+	type found struct {
+		path string
+		data []byte
+	}
+	bySource := map[string]found{}
+	return filepath.WalkDir(root, func(path string, item os.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if item.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		var entry store.Entry
+		if json.Unmarshal(data, &entry) != nil || entry.Source == "" {
+			return nil
+		}
+		previous, exists := bySource[entry.Source]
+		if !exists {
+			bySource[entry.Source] = found{path: path, data: data}
+			return nil
+		}
+		winner := newerEntry(previous.data, data)
+		if bytes.Equal(winner, previous.data) {
+			return os.Remove(path)
+		}
+		if err := os.Remove(previous.path); err != nil {
+			return err
+		}
+		bySource[entry.Source] = found{path: path, data: data}
+		return nil
+	})
+}
+
+func (m *Manager) Status(ctx context.Context) (Status, error) {
+	status := Status{URL: m.URL, Branch: m.Branch}
+	if !m.isGitRepository() || !m.hasOrigin(ctx) {
+		return status, nil
+	}
+	status.Initialized = true
+	if output, err := m.git(ctx, "remote", "get-url", "origin"); err == nil {
+		status.URL = strings.TrimSpace(string(output))
+	}
+	output, err := m.git(ctx, "status", "--porcelain")
+	if err != nil {
+		return status, err
+	}
+	status.Dirty = len(bytes.TrimSpace(output)) > 0
+	if _, err := m.git(ctx, "rev-parse", "--verify", "origin/"+m.Branch); err == nil {
+		counts, err := m.git(ctx, "rev-list", "--left-right", "--count", "origin/"+m.Branch+"...HEAD")
+		if err == nil {
+			_, _ = fmt.Sscanf(string(counts), "%d %d", &status.Behind, &status.Ahead)
+		}
+	}
+	return status, nil
+}
+
+func (m *Manager) Disconnect(ctx context.Context) error {
+	if !m.isGitRepository() {
+		return nil
+	}
+	if _, err := m.git(ctx, "remote", "get-url", "origin"); err != nil {
+		return nil
+	}
+	_, err := m.git(ctx, "remote", "remove", "origin")
+	return err
+}
+
+func (m *Manager) commit(ctx context.Context, message string) error {
+	if _, err := m.git(ctx, "add", "-A"); err != nil {
+		return err
+	}
+	cmd := m.command(ctx, "diff", "--cached", "--quiet")
+	if err := cmd.Run(); err == nil {
+		if _, mergeErr := os.Stat(filepath.Join(m.Repository.Root, ".git", "MERGE_HEAD")); os.IsNotExist(mergeErr) {
+			return nil
+		}
+	} else {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+			return err
+		}
+	}
+	_, err := m.git(ctx, "-c", "user.name=DevLog", "-c", "user.email=devlog@local", "commit", "-m", message)
+	return err
+}
+
+func (m *Manager) remoteBranchExists(ctx context.Context) (bool, error) {
+	cmd := m.command(ctx, "ls-remote", "--exit-code", "--heads", "origin", m.Branch)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return len(bytes.TrimSpace(output)) > 0, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 2 {
+		return false, nil
+	}
+	return false, commandError(cmd, output, err)
+}
+
+func (m *Manager) isGitRepository() bool {
+	info, err := os.Stat(filepath.Join(m.Repository.Root, ".git"))
+	return err == nil && info.IsDir()
+}
+
+func (m *Manager) hasOrigin(ctx context.Context) bool {
+	_, err := m.git(ctx, "remote", "get-url", "origin")
+	return err == nil
+}
+
+func (m *Manager) command(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = m.Repository.Root
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	return cmd
+}
+
+func (m *Manager) git(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := m.command(ctx, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return output, commandError(cmd, output, err)
+	}
+	return output, nil
+}
+
+func commandError(cmd *exec.Cmd, output []byte, err error) error {
+	message := strings.TrimSpace(string(output))
+	if message == "" {
+		message = err.Error()
+	}
+	return fmt.Errorf("git %s failed: %s", strings.Join(cmd.Args[1:], " "), message)
+}
+
+func atomicWrite(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".devlog-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/gitremote/gitremote.go
+++ b/internal/gitremote/gitremote.go
@@ -262,7 +262,7 @@ func (m *Manager) reconcileDuplicateSources() error {
 		path string
 		data []byte
 	}
-	bySource := map[string]found{}
+	byDateAndSource := map[string]found{}
 	return filepath.WalkDir(root, func(path string, item os.DirEntry, err error) error {
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -281,9 +281,10 @@ func (m *Manager) reconcileDuplicateSources() error {
 		if json.Unmarshal(data, &entry) != nil || entry.Source == "" {
 			return nil
 		}
-		previous, exists := bySource[entry.Source]
+		key := filepath.Dir(path) + "\x00" + entry.Source
+		previous, exists := byDateAndSource[key]
 		if !exists {
-			bySource[entry.Source] = found{path: path, data: data}
+			byDateAndSource[key] = found{path: path, data: data}
 			return nil
 		}
 		winner := newerEntry(previous.data, data)
@@ -293,7 +294,7 @@ func (m *Manager) reconcileDuplicateSources() error {
 		if err := os.Remove(previous.path); err != nil {
 			return err
 		}
-		bySource[entry.Source] = found{path: path, data: data}
+		byDateAndSource[key] = found{path: path, data: data}
 		return nil
 	})
 }

--- a/internal/gitremote/gitremote_test.go
+++ b/internal/gitremote/gitremote_test.go
@@ -1,0 +1,139 @@
+package gitremote
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"devlog/internal/store"
+)
+
+func TestTwoMachineSynchronization(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not installed")
+	}
+	ctx := context.Background()
+	root := t.TempDir()
+	bare := filepath.Join(root, "remote.git")
+	cmd := exec.Command("git", "init", "--bare", bare)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare failed: %s", output)
+	}
+
+	repoA := newTestRepository(t, filepath.Join(root, "machine-a"))
+	repoB := newTestRepository(t, filepath.Join(root, "machine-b"))
+	managerA := New(repoA, bare, "main")
+	managerB := New(repoB, bare, "main")
+	if err := managerA.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := managerB.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	date := time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC)
+	now := time.Now().UTC()
+	_, err := repoA.AddEntries(date, []store.Entry{{Id: "from-a", Project: "a", Description: "A", CreatedAt: now, UpdatedAt: now}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = repoB.AddEntries(date, []store.Entry{{Id: "from-b", Project: "b", Description: "B", CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second)}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := managerA.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := managerB.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := managerA.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	assertEntryCount(t, repoA, date, 2)
+	assertEntryCount(t, repoB, date, 2)
+
+	source := "github:commit:same"
+	older := now.Add(2 * time.Second)
+	newer := older.Add(time.Second)
+	_, _ = repoA.AddEntries(date, []store.Entry{{Id: store.EntryID(source), Source: source, Description: "older", CreatedAt: older, UpdatedAt: older}})
+	_, _ = repoB.AddEntries(date, []store.Entry{{Id: store.EntryID(source), Source: source, Description: "newer", CreatedAt: newer, UpdatedAt: newer}})
+	if err := managerA.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := managerB.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := repoB.Entries(date)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := 0
+	for _, entry := range entries {
+		if entry.Source == source {
+			seen++
+			if entry.Description != "newer" {
+				t.Fatalf("conflict winner = %q, want newer", entry.Description)
+			}
+		}
+	}
+	if seen != 1 {
+		t.Fatalf("saw duplicated external source %d times", seen)
+	}
+
+	if err := managerA.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	olderSummary := store.Summary{Date: date, Style: "concise", Content: "from A", GeneratedAt: now.Add(4 * time.Second), DeviceID: "machine-a"}
+	newerSummary := store.Summary{Date: date, Style: "concise", Content: "from B", GeneratedAt: now.Add(5 * time.Second), DeviceID: "machine-b"}
+	if err := repoA.SaveSummary(olderSummary); err != nil {
+		t.Fatal(err)
+	}
+	if err := repoB.SaveSummary(newerSummary); err != nil {
+		t.Fatal(err)
+	}
+	if err := managerA.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := managerB.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := repoB.LoadSummary(date)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Content != "from B" {
+		t.Fatalf("summary conflict winner = %q, want from B", loaded.Content)
+	}
+	conflicts, err := os.ReadDir(filepath.Join(repoB.Root, "summaries", "conflicts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(conflicts) != 1 {
+		t.Fatalf("preserved summary conflicts = %d, want 1", len(conflicts))
+	}
+}
+
+func newTestRepository(t *testing.T, root string) *store.Repository {
+	t.Helper()
+	configRoot := filepath.Join(root, "config")
+	repo := store.NewRepository(filepath.Join(root, "data"), configRoot)
+	if _, err := repo.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	return repo
+}
+
+func assertEntryCount(t *testing.T, repo *store.Repository, date time.Time, wanted int) {
+	t.Helper()
+	entries, err := repo.Entries(date)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != wanted {
+		t.Fatalf("entry count = %d, want %d", len(entries), wanted)
+	}
+}

--- a/internal/gitremote/gitremote_test.go
+++ b/internal/gitremote/gitremote_test.go
@@ -117,6 +117,50 @@ func TestTwoMachineSynchronization(t *testing.T) {
 	}
 }
 
+func TestSynchronizationPreservesSameSourceOnDifferentDates(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not installed")
+	}
+	ctx := context.Background()
+	root := t.TempDir()
+	bare := filepath.Join(root, "remote.git")
+	if output, err := exec.Command("git", "init", "--bare", bare).CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare failed: %s", output)
+	}
+
+	repoA := newTestRepository(t, filepath.Join(root, "machine-a"))
+	repoB := newTestRepository(t, filepath.Join(root, "machine-b"))
+	managerA := New(repoA, bare, "main")
+	managerB := New(repoB, bare, "main")
+	if err := managerA.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := managerB.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	firstDate := time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC)
+	secondDate := firstDate.AddDate(0, 0, 1)
+	legacySource := "github:review:acme/widgets#42"
+	_, err := repoA.AddEntries(firstDate, []store.Entry{{Source: legacySource, Description: "first review", CreatedAt: firstDate}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = repoB.AddEntries(secondDate, []store.Entry{{Source: legacySource, Description: "second review", CreatedAt: secondDate}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := managerA.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := managerB.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	assertEntryCount(t, repoB, firstDate, 1)
+	assertEntryCount(t, repoB, secondDate, 1)
+}
+
 func newTestRepository(t *testing.T, root string) *store.Repository {
 	t.Helper()
 	configRoot := filepath.Join(root, "config")

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -1,0 +1,139 @@
+// Package llm provides a minimal client for OpenAI-compatible chat
+// completions endpoints (OpenRouter by default), used to generate
+// polished summaries and entries.
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+// providerBaseURLs maps known llm.provider values to their API base URL.
+var providerBaseURLs = map[string]string{
+	"openrouter": "https://openrouter.ai/api/v1",
+	"openai":     "https://api.openai.com/v1",
+}
+
+// Client calls an OpenAI-compatible chat completions API.
+type Client struct {
+	baseURL string
+	apiKey  string
+	model   string
+	http    *http.Client
+}
+
+// NewFromConfig builds a client from the llm.* keys in the devlog config.
+func NewFromConfig() (*Client, error) {
+	if !viper.GetBool("llm.enabled") {
+		return nil, fmt.Errorf("LLM support is disabled — set llm.enabled to true in ~/.devlog/config.json")
+	}
+
+	baseURL := viper.GetString("llm.baseURL")
+	if baseURL == "" {
+		provider := viper.GetString("llm.provider")
+		known, ok := providerBaseURLs[provider]
+		if !ok {
+			return nil, fmt.Errorf("unknown llm.provider %q — set llm.baseURL for a custom OpenAI-compatible endpoint", provider)
+		}
+		baseURL = known
+	}
+
+	model := viper.GetString("llm.model")
+	if model == "" {
+		return nil, fmt.Errorf("llm.model is not set in the devlog config")
+	}
+
+	apiKeyEnvVar := viper.GetString("llm.apiKeyEnvVar")
+	if apiKeyEnvVar == "" {
+		apiKeyEnvVar = "OPENROUTER_API_KEY"
+	}
+	apiKey := os.Getenv(apiKeyEnvVar)
+	if apiKey == "" {
+		return nil, fmt.Errorf("no API key found — set the %s environment variable", apiKeyEnvVar)
+	}
+
+	return &Client{
+		baseURL: baseURL,
+		apiKey:  apiKey,
+		model:   model,
+		http:    &http.Client{Timeout: 60 * time.Second},
+	}, nil
+}
+
+type chatRequest struct {
+	Model       string        `json:"model"`
+	Messages    []chatMessage `json:"messages"`
+	Temperature float64       `json:"temperature"`
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatResponse struct {
+	Choices []struct {
+		Message chatMessage `json:"message"`
+	} `json:"choices"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// Complete sends a single-turn system+user prompt and returns the reply text.
+func (c *Client) Complete(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
+	body, err := json.Marshal(chatRequest{
+		Model: c.model,
+		Messages: []chatMessage{
+			{Role: "system", Content: systemPrompt},
+			{Role: "user", Content: userPrompt},
+		},
+		Temperature: 0.3,
+	})
+	if err != nil {
+		return "", fmt.Errorf("error encoding request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("error building request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error calling LLM API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("error reading LLM response: %w", err)
+	}
+
+	var parsed chatResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", fmt.Errorf("error parsing LLM response (status %d): %w", resp.StatusCode, err)
+	}
+
+	if parsed.Error != nil {
+		return "", fmt.Errorf("LLM API error: %s", parsed.Error.Message)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("LLM API returned status %d", resp.StatusCode)
+	}
+	if len(parsed.Choices) == 0 || parsed.Choices[0].Message.Content == "" {
+		return "", fmt.Errorf("LLM API returned an empty response")
+	}
+
+	return parsed.Choices[0].Message.Content, nil
+}

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -20,6 +20,7 @@ import (
 var providerBaseURLs = map[string]string{
 	"openrouter": "https://openrouter.ai/api/v1",
 	"openai":     "https://api.openai.com/v1",
+	"deepseek":   "https://api.deepseek.com",
 }
 
 // Client calls an OpenAI-compatible chat completions API.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -23,6 +23,7 @@ type Options struct {
 	Hour       int
 	Minute     int
 	Polish     bool
+	Remote     bool
 	EnvFile    string
 	LogFile    string
 }
@@ -127,6 +128,9 @@ func arguments(opts Options) []string {
 	args := []string{"sync"}
 	if opts.Polish {
 		args = append(args, "--polish")
+	}
+	if opts.Remote {
+		args = append(args, "--remote")
 	}
 	if opts.EnvFile != "" {
 		args = append(args, "--env-file", opts.EnvFile)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,0 +1,261 @@
+// Package scheduler installs and manages the platform-native daily sync job.
+package scheduler
+
+import (
+	"fmt"
+	"html"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+const (
+	launchdLabel = "com.gustmrg.devlog.sync"
+	cronBegin    = "# BEGIN devlog sync"
+	cronEnd      = "# END devlog sync"
+)
+
+type Options struct {
+	Executable string
+	Hour       int
+	Minute     int
+	Polish     bool
+	EnvFile    string
+	LogFile    string
+}
+
+func ParseTime(value string) (int, int, error) {
+	parts := strings.Split(value, ":")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid time %q: expected HH:MM", value)
+	}
+	hour, err := strconv.Atoi(parts[0])
+	if err != nil || hour < 0 || hour > 23 {
+		return 0, 0, fmt.Errorf("invalid hour in %q", value)
+	}
+	minute, err := strconv.Atoi(parts[1])
+	if err != nil || minute < 0 || minute > 59 {
+		return 0, 0, fmt.Errorf("invalid minute in %q", value)
+	}
+	return hour, minute, nil
+}
+
+func Install(opts Options) (string, error) {
+	if err := validate(opts); err != nil {
+		return "", err
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return installLaunchd(opts)
+	case "linux":
+		return installCron(opts)
+	default:
+		return "", fmt.Errorf("automatic sync is not supported on %s", runtime.GOOS)
+	}
+}
+
+func Show() (string, bool, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		path, err := launchdPath()
+		if err != nil {
+			return "", false, err
+		}
+		data, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			return "", false, nil
+		}
+		return string(data), err == nil, err
+	case "linux":
+		current, err := readCrontab()
+		if err != nil {
+			return "", false, err
+		}
+		block := managedCronBlock(current)
+		return block, block != "", nil
+	default:
+		return "", false, fmt.Errorf("automatic sync is not supported on %s", runtime.GOOS)
+	}
+}
+
+func Remove() (bool, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		path, err := launchdPath()
+		if err != nil {
+			return false, err
+		}
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return false, nil
+		}
+		_ = exec.Command("launchctl", "unload", path).Run()
+		return true, os.Remove(path)
+	case "linux":
+		current, err := readCrontab()
+		if err != nil {
+			return false, err
+		}
+		if managedCronBlock(current) == "" {
+			return false, nil
+		}
+		return true, writeCrontab(removeManagedCronBlock(current))
+	default:
+		return false, fmt.Errorf("automatic sync is not supported on %s", runtime.GOOS)
+	}
+}
+
+func validate(opts Options) error {
+	if opts.Executable == "" || !filepath.IsAbs(opts.Executable) {
+		return fmt.Errorf("devlog executable path must be absolute")
+	}
+	if opts.Hour < 0 || opts.Hour > 23 || opts.Minute < 0 || opts.Minute > 59 {
+		return fmt.Errorf("invalid schedule time")
+	}
+	if opts.LogFile == "" || !filepath.IsAbs(opts.LogFile) {
+		return fmt.Errorf("log file path must be absolute")
+	}
+	if opts.EnvFile != "" && !filepath.IsAbs(opts.EnvFile) {
+		return fmt.Errorf("environment file path must be absolute")
+	}
+	return nil
+}
+
+func arguments(opts Options) []string {
+	args := []string{"sync"}
+	if opts.Polish {
+		args = append(args, "--polish")
+	}
+	if opts.EnvFile != "" {
+		args = append(args, "--env-file", opts.EnvFile)
+	}
+	return args
+}
+
+func launchdDefinition(opts Options) string {
+	var args strings.Builder
+	for _, arg := range append([]string{opts.Executable}, arguments(opts)...) {
+		fmt.Fprintf(&args, "    <string>%s</string>\n", html.EscapeString(arg))
+	}
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>%s</string>
+  <key>ProgramArguments</key>
+  <array>
+%s  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key><integer>%d</integer>
+    <key>Minute</key><integer>%d</integer>
+  </dict>
+  <key>StandardOutPath</key><string>%s</string>
+  <key>StandardErrorPath</key><string>%s</string>
+</dict>
+</plist>
+`, launchdLabel, args.String(), opts.Hour, opts.Minute, html.EscapeString(opts.LogFile), html.EscapeString(opts.LogFile))
+}
+
+func launchdPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", launchdLabel+".plist"), nil
+}
+
+func installLaunchd(opts Options) (string, error) {
+	path, err := launchdPath()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return "", err
+	}
+	_ = exec.Command("launchctl", "unload", path).Run()
+	if err := os.WriteFile(path, []byte(launchdDefinition(opts)), 0644); err != nil {
+		return "", err
+	}
+	if output, err := exec.Command("launchctl", "load", path).CombinedOutput(); err != nil {
+		return "", fmt.Errorf("launchctl load failed: %s", strings.TrimSpace(string(output)))
+	}
+	return path, nil
+}
+
+func cronDefinition(opts Options) string {
+	parts := []string{shellQuote(opts.Executable)}
+	for _, arg := range arguments(opts) {
+		parts = append(parts, shellQuote(arg))
+	}
+	return fmt.Sprintf("%d %d * * * %s >> %s 2>&1", opts.Minute, opts.Hour, strings.Join(parts, " "), shellQuote(opts.LogFile))
+}
+
+func installCron(opts Options) (string, error) {
+	current, err := readCrontab()
+	if err != nil {
+		return "", err
+	}
+	updated := strings.TrimSpace(removeManagedCronBlock(current))
+	if updated != "" {
+		updated += "\n\n"
+	}
+	updated += cronBegin + "\n" + cronDefinition(opts) + "\n" + cronEnd + "\n"
+	if err := writeCrontab(updated); err != nil {
+		return "", err
+	}
+	return "user crontab", nil
+}
+
+func readCrontab() (string, error) {
+	output, err := exec.Command("crontab", "-l").CombinedOutput()
+	if err == nil {
+		return string(output), nil
+	}
+	if strings.Contains(strings.ToLower(string(output)), "no crontab") {
+		return "", nil
+	}
+	return "", fmt.Errorf("could not read crontab: %s", strings.TrimSpace(string(output)))
+}
+
+func writeCrontab(content string) error {
+	cmd := exec.Command("crontab", "-")
+	cmd.Stdin = strings.NewReader(content)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("could not update crontab: %s", strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func managedCronBlock(content string) string {
+	start := strings.Index(content, cronBegin)
+	if start < 0 {
+		return ""
+	}
+	rest := content[start:]
+	end := strings.Index(rest, cronEnd)
+	if end < 0 {
+		return ""
+	}
+	return strings.TrimSpace(rest[:end+len(cronEnd)])
+}
+
+func removeManagedCronBlock(content string) string {
+	block := managedCronBlock(content)
+	if block == "" {
+		return content
+	}
+	return strings.TrimSpace(strings.Replace(content, block, "", 1)) + "\n"
+}
+
+func shellQuote(value string) string {
+	if value != "" && strings.IndexFunc(value, func(r rune) bool {
+		return !(r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || strings.ContainsRune("_@%+=:,./-", r))
+	}) == -1 {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -23,6 +23,7 @@ func TestLaunchdDefinition(t *testing.T) {
 		Hour:       23,
 		Minute:     55,
 		Polish:     true,
+		Remote:     true,
 		EnvFile:    "/Users/test/.devlog/sync.env",
 		LogFile:    "/Users/test/.devlog/sync.log",
 	}
@@ -30,6 +31,7 @@ func TestLaunchdDefinition(t *testing.T) {
 	for _, expected := range []string{
 		"<string>/Applications/Dev Log/devlog</string>",
 		"<string>--polish</string>",
+		"<string>--remote</string>",
 		"<string>--env-file</string>",
 		"<key>Hour</key><integer>23</integer>",
 		"<key>Minute</key><integer>55</integer>",
@@ -45,6 +47,7 @@ func TestCronDefinitionQuotesPaths(t *testing.T) {
 		Executable: "/home/test/dev log/devlog",
 		Hour:       8,
 		Minute:     30,
+		Remote:     true,
 		EnvFile:    "/home/test/it's.env",
 		LogFile:    "/home/test/dev log/sync.log",
 	}
@@ -57,6 +60,9 @@ func TestCronDefinitionQuotesPaths(t *testing.T) {
 	}
 	if !strings.Contains(definition, `'/home/test/it'"'"'s.env'`) {
 		t.Errorf("single quote was not escaped: %s", definition)
+	}
+	if !strings.Contains(definition, " sync --remote --env-file ") {
+		t.Errorf("remote sync arguments are missing: %s", definition)
 	}
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,73 @@
+package scheduler
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseTime(t *testing.T) {
+	hour, minute, err := ParseTime("07:05")
+	if err != nil || hour != 7 || minute != 5 {
+		t.Fatalf("ParseTime() = %d, %d, %v", hour, minute, err)
+	}
+	for _, value := range []string{"7", "24:00", "12:60", "aa:10"} {
+		if _, _, err := ParseTime(value); err == nil {
+			t.Errorf("ParseTime(%q) unexpectedly succeeded", value)
+		}
+	}
+}
+
+func TestLaunchdDefinition(t *testing.T) {
+	opts := Options{
+		Executable: "/Applications/Dev Log/devlog",
+		Hour:       23,
+		Minute:     55,
+		Polish:     true,
+		EnvFile:    "/Users/test/.devlog/sync.env",
+		LogFile:    "/Users/test/.devlog/sync.log",
+	}
+	definition := launchdDefinition(opts)
+	for _, expected := range []string{
+		"<string>/Applications/Dev Log/devlog</string>",
+		"<string>--polish</string>",
+		"<string>--env-file</string>",
+		"<key>Hour</key><integer>23</integer>",
+		"<key>Minute</key><integer>55</integer>",
+	} {
+		if !strings.Contains(definition, expected) {
+			t.Errorf("launchd definition does not contain %q", expected)
+		}
+	}
+}
+
+func TestCronDefinitionQuotesPaths(t *testing.T) {
+	opts := Options{
+		Executable: "/home/test/dev log/devlog",
+		Hour:       8,
+		Minute:     30,
+		EnvFile:    "/home/test/it's.env",
+		LogFile:    "/home/test/dev log/sync.log",
+	}
+	definition := cronDefinition(opts)
+	if !strings.HasPrefix(definition, "30 8 * * * ") {
+		t.Fatalf("unexpected cron schedule: %s", definition)
+	}
+	if !strings.Contains(definition, `'/home/test/dev log/devlog'`) {
+		t.Errorf("executable path was not quoted: %s", definition)
+	}
+	if !strings.Contains(definition, `'/home/test/it'"'"'s.env'`) {
+		t.Errorf("single quote was not escaped: %s", definition)
+	}
+}
+
+func TestManagedCronBlockReplacement(t *testing.T) {
+	content := "MAILTO=user@example.com\n\n" + cronBegin + "\nold job\n" + cronEnd + "\n\n0 1 * * * backup\n"
+	block := managedCronBlock(content)
+	if !strings.Contains(block, "old job") {
+		t.Fatalf("managed block not found: %q", block)
+	}
+	remaining := removeManagedCronBlock(content)
+	if strings.Contains(remaining, "old job") || !strings.Contains(remaining, "MAILTO=user@example.com") || !strings.Contains(remaining, "backup") {
+		t.Fatalf("unexpected remaining crontab: %q", remaining)
+	}
+}

--- a/internal/store/lock_unix.go
+++ b/internal/store/lock_unix.go
@@ -1,0 +1,16 @@
+//go:build darwin || linux
+
+package store
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_EX)
+}
+
+func unlockFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+}

--- a/internal/store/lock_windows.go
+++ b/internal/store/lock_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package store
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped)
+}
+
+func unlockFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped)
+}

--- a/internal/store/migration.go
+++ b/internal/store/migration.go
@@ -1,0 +1,97 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func (r *Repository) migrateLegacyUnlocked() (MigrationResult, error) {
+	result := MigrationResult{}
+	legacyEntries := filepath.Join(r.ConfigRoot, "entries")
+	legacySummaries := filepath.Join(r.ConfigRoot, "summaries")
+	entryFiles, err := os.ReadDir(legacyEntries)
+	if err != nil && !os.IsNotExist(err) {
+		return result, err
+	}
+	summaryFiles, err := os.ReadDir(legacySummaries)
+	if err != nil && !os.IsNotExist(err) {
+		return result, err
+	}
+	if len(entryFiles) == 0 && len(summaryFiles) == 0 {
+		return result, nil
+	}
+
+	backup := filepath.Join(r.ConfigRoot, "backups", "migration-"+time.Now().UTC().Format("20060102T150405.000000000Z"))
+	if err := os.MkdirAll(backup, 0700); err != nil {
+		return result, err
+	}
+	result.BackupPath = backup
+
+	for _, item := range entryFiles {
+		if item.IsDir() || filepath.Ext(item.Name()) != ".json" {
+			continue
+		}
+		src := filepath.Join(legacyEntries, item.Name())
+		if err := os.MkdirAll(filepath.Join(backup, "entries"), 0700); err != nil {
+			return result, err
+		}
+		if err := copyFile(src, filepath.Join(backup, "entries", item.Name())); err != nil {
+			return result, err
+		}
+		log, err := LoadDailyLog(src)
+		if err != nil {
+			return result, err
+		}
+		dateText := strings.TrimSuffix(item.Name(), filepath.Ext(item.Name()))
+		date, err := time.Parse("2006-01-02", dateText)
+		if err != nil {
+			return result, fmt.Errorf("invalid legacy entry filename %s", item.Name())
+		}
+		dir := filepath.Join(r.Root, "entries", date.Format("2006-01-02"))
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return result, err
+		}
+		for _, entry := range log.Entries {
+			entry.Id = normalizedEntryID(entry.Id, entry.Source)
+			if entry.UpdatedAt.IsZero() {
+				entry.UpdatedAt = entry.CreatedAt
+			}
+			data, err := marshalEntry(entry)
+			if err != nil {
+				return result, err
+			}
+			if err := atomicWrite(filepath.Join(dir, entry.Id+".json"), data, 0644); err != nil {
+				return result, err
+			}
+			result.MigratedEntries++
+		}
+	}
+
+	for _, item := range summaryFiles {
+		if item.IsDir() || filepath.Ext(item.Name()) != ".md" {
+			continue
+		}
+		if err := os.MkdirAll(filepath.Join(backup, "summaries"), 0700); err != nil {
+			return result, err
+		}
+		src := filepath.Join(legacySummaries, item.Name())
+		if err := copyFile(src, filepath.Join(backup, "summaries", item.Name())); err != nil {
+			return result, err
+		}
+		if err := os.MkdirAll(filepath.Join(r.Root, "summaries"), 0755); err != nil {
+			return result, err
+		}
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return result, err
+		}
+		if err := atomicWrite(filepath.Join(r.Root, "summaries", item.Name()), data, 0644); err != nil {
+			return result, err
+		}
+		result.MigratedSummaries++
+	}
+	return result, nil
+}

--- a/internal/store/repository.go
+++ b/internal/store/repository.go
@@ -1,0 +1,424 @@
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/viper"
+)
+
+const DataVersion = "1"
+
+type Repository struct {
+	Root       string
+	ConfigRoot string
+}
+
+type MigrationResult struct {
+	MigratedEntries   int
+	MigratedSummaries int
+	BackupPath        string
+	AlreadyCurrent    bool
+}
+
+func OpenRepository() (*Repository, error) {
+	repo, _, err := openRepository()
+	return repo, err
+}
+
+func MigrateRepository() (*Repository, MigrationResult, error) {
+	return openRepository()
+}
+
+func openRepository() (*Repository, MigrationResult, error) {
+	configRoot, err := ConfigPath()
+	if err != nil {
+		return nil, MigrationResult{}, err
+	}
+	root := viper.GetString("storage.path")
+	if root == "" {
+		root = filepath.Join(configRoot, "data")
+	} else {
+		root, err = expandPath(root)
+		if err != nil {
+			return nil, MigrationResult{}, err
+		}
+	}
+	repo := &Repository{Root: root, ConfigRoot: configRoot}
+	if unsafeDataRoot(root, configRoot) {
+		return nil, MigrationResult{}, fmt.Errorf("storage.path must not contain ~/.devlog configuration; choose a dedicated data directory")
+	}
+	result, err := repo.EnsureLayout()
+	if err != nil {
+		return nil, MigrationResult{}, err
+	}
+	return repo, result, nil
+}
+
+func NewRepository(root, configRoot string) *Repository {
+	return &Repository{Root: root, ConfigRoot: configRoot}
+}
+
+func (r *Repository) EnsureLayout() (MigrationResult, error) {
+	if err := os.MkdirAll(r.Root, 0755); err != nil {
+		return MigrationResult{}, err
+	}
+	unlock, err := r.Lock()
+	if err != nil {
+		return MigrationResult{}, err
+	}
+	defer unlock()
+	return r.ensureLayoutUnlocked()
+}
+
+func (r *Repository) ensureLayoutUnlocked() (MigrationResult, error) {
+	versionPath := filepath.Join(r.Root, ".devlog-version")
+	if data, err := os.ReadFile(versionPath); err == nil {
+		if strings.TrimSpace(string(data)) != DataVersion {
+			return MigrationResult{}, fmt.Errorf("unsupported devlog data version %q", strings.TrimSpace(string(data)))
+		}
+		return MigrationResult{AlreadyCurrent: true}, nil
+	} else if !os.IsNotExist(err) {
+		return MigrationResult{}, err
+	}
+
+	result, err := r.migrateLegacyUnlocked()
+	if err != nil {
+		return MigrationResult{}, err
+	}
+	if err := os.MkdirAll(filepath.Join(r.Root, "entries"), 0755); err != nil {
+		return MigrationResult{}, err
+	}
+	if err := os.MkdirAll(filepath.Join(r.Root, "summaries"), 0755); err != nil {
+		return MigrationResult{}, err
+	}
+	if err := atomicWrite(versionPath, []byte(DataVersion+"\n"), 0644); err != nil {
+		return MigrationResult{}, err
+	}
+	if err := r.ensureGitignore(); err != nil {
+		return MigrationResult{}, err
+	}
+	return result, nil
+}
+
+func (r *Repository) Migrate() (MigrationResult, error) {
+	return r.EnsureLayout()
+}
+
+func (r *Repository) Lock() (func(), error) {
+	if err := os.MkdirAll(r.Root, 0755); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(filepath.Join(r.Root, ".devlog.lock"), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+		file.Close()
+		return nil, err
+	}
+	return func() {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = file.Close()
+	}, nil
+}
+
+func (r *Repository) AddEntries(date time.Time, entries []Entry) ([]Entry, error) {
+	unlock, err := r.Lock()
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	existing, err := r.entriesUnlocked(date)
+	if err != nil {
+		return nil, err
+	}
+	ids := make(map[string]bool, len(existing))
+	sources := make(map[string]bool, len(existing))
+	for _, entry := range existing {
+		ids[entry.Id] = true
+		if entry.Source != "" {
+			sources[entry.Source] = true
+		}
+	}
+
+	dir := filepath.Join(r.Root, "entries", date.Format("2006-01-02"))
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, err
+	}
+	var added []Entry
+	for _, entry := range entries {
+		entry.Id = normalizedEntryID(entry.Id, entry.Source)
+		if ids[entry.Id] || entry.Source != "" && sources[entry.Source] {
+			continue
+		}
+		if entry.UpdatedAt.IsZero() {
+			entry.UpdatedAt = entry.CreatedAt
+		}
+		data, err := json.MarshalIndent(entry, "", "  ")
+		if err != nil {
+			return added, err
+		}
+		if err := atomicWrite(filepath.Join(dir, entry.Id+".json"), append(data, '\n'), 0644); err != nil {
+			return added, err
+		}
+		ids[entry.Id] = true
+		if entry.Source != "" {
+			sources[entry.Source] = true
+		}
+		added = append(added, entry)
+	}
+	return added, nil
+}
+
+func (r *Repository) Entries(date time.Time) ([]Entry, error) {
+	unlock, err := r.Lock()
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+	return r.entriesUnlocked(date)
+}
+
+func (r *Repository) entriesUnlocked(date time.Time) ([]Entry, error) {
+	dir := filepath.Join(r.Root, "entries", date.Format("2006-01-02"))
+	items, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]Entry, 0, len(items))
+	for _, item := range items {
+		if item.IsDir() || filepath.Ext(item.Name()) != ".json" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, item.Name()))
+		if err != nil {
+			return nil, err
+		}
+		var entry Entry
+		if err := json.Unmarshal(data, &entry); err != nil {
+			return nil, fmt.Errorf("error parsing entry %s: %w", item.Name(), err)
+		}
+		if entry.DeletedAt != nil {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].CreatedAt.Equal(entries[j].CreatedAt) {
+			return entries[i].Id < entries[j].Id
+		}
+		return entries[i].CreatedAt.Before(entries[j].CreatedAt)
+	})
+	return entries, nil
+}
+
+func (r *Repository) SummaryPath(date time.Time) string {
+	return filepath.Join(r.Root, "summaries", date.Format("2006-01-02")+".md")
+}
+
+func (r *Repository) SaveSummary(summary Summary) error {
+	unlock, err := r.Lock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	if summary.GeneratedAt.IsZero() {
+		summary.GeneratedAt = time.Now().UTC()
+	}
+	if summary.DeviceID == "" {
+		summary.DeviceID, _ = DeviceID(r.ConfigRoot)
+	}
+	if err := os.MkdirAll(filepath.Join(r.Root, "summaries"), 0755); err != nil {
+		return err
+	}
+	return saveSummaryAtomic(r.SummaryPath(summary.Date), summary)
+}
+
+func (r *Repository) LoadSummary(date time.Time) (Summary, error) {
+	return LoadSummary(r.SummaryPath(date))
+}
+
+func (r *Repository) SummaryFiles() ([]string, error) {
+	dir := filepath.Join(r.Root, "summaries")
+	items, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var paths []string
+	for _, item := range items {
+		if !item.IsDir() && strings.HasSuffix(item.Name(), ".md") {
+			paths = append(paths, filepath.Join(dir, item.Name()))
+		}
+	}
+	return paths, nil
+}
+
+func EntryID(source string) string {
+	if source == "" {
+		return uuid.NewString()
+	}
+	return uuid.NewSHA1(uuid.NameSpaceURL, []byte(source)).String()
+}
+
+func normalizedEntryID(id, source string) string {
+	if source != "" {
+		return EntryID(source)
+	}
+	if id == "" {
+		return EntryID("")
+	}
+	if len(id) <= 128 && id != "." && id != ".." && strings.IndexFunc(id, func(r rune) bool {
+		return !(r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' || r == '.')
+	}) == -1 {
+		return id
+	}
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte("legacy-entry:"+id)).String()
+}
+
+func DeviceID(configRoot string) (string, error) {
+	path := filepath.Join(configRoot, "device-id")
+	if data, err := os.ReadFile(path); err == nil {
+		return strings.TrimSpace(string(data)), nil
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	id := uuid.NewString()
+	if err := atomicWrite(path, []byte(id+"\n"), 0600); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+func (r *Repository) ensureGitignore() error {
+	path := filepath.Join(r.Root, ".gitignore")
+	const required = ".devlog.lock\n*.tmp\n"
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return atomicWrite(path, []byte(required), 0644)
+	}
+	if err != nil {
+		return err
+	}
+	content := string(data)
+	changed := false
+	for _, line := range strings.Split(strings.TrimSpace(required), "\n") {
+		if !containsLine(content, line) {
+			if content != "" && !strings.HasSuffix(content, "\n") {
+				content += "\n"
+			}
+			content += line + "\n"
+			changed = true
+		}
+	}
+	if changed {
+		return atomicWrite(path, []byte(content), 0644)
+	}
+	return nil
+}
+
+func containsLine(content, wanted string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func atomicWrite(path string, data []byte, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".devlog-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func expandPath(path string) (string, error) {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
+	}
+	return filepath.Abs(path)
+}
+
+func unsafeDataRoot(root, configRoot string) bool {
+	root, _ = filepath.Abs(root)
+	configRoot, _ = filepath.Abs(configRoot)
+	if pathContains(root, configRoot) {
+		return true
+	}
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
+	}
+	if resolved, err := filepath.EvalSymlinks(configRoot); err == nil {
+		configRoot = resolved
+	}
+	return pathContains(root, configRoot)
+}
+
+func pathContains(root, path string) bool {
+	if root == path {
+		return true
+	}
+	rel, err := filepath.Rel(root, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_EXCL|os.O_WRONLY, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(out, in)
+	closeErr := out.Close()
+	return errors.Join(copyErr, closeErr)
+}

--- a/internal/store/repository.go
+++ b/internal/store/repository.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -122,12 +121,12 @@ func (r *Repository) Lock() (func(), error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+	if err := lockFile(file); err != nil {
 		file.Close()
 		return nil, err
 	}
 	return func() {
-		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = unlockFile(file)
 		_ = file.Close()
 	}, nil
 }

--- a/internal/store/repository_test.go
+++ b/internal/store/repository_test.go
@@ -1,0 +1,131 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRepositoryMigratesLegacyData(t *testing.T) {
+	configRoot := t.TempDir()
+	dataRoot := filepath.Join(configRoot, "data")
+	legacyEntries := filepath.Join(configRoot, "entries")
+	legacySummaries := filepath.Join(configRoot, "summaries")
+	if err := os.MkdirAll(legacyEntries, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(legacySummaries, 0755); err != nil {
+		t.Fatal(err)
+	}
+	date := time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC)
+	created := time.Date(2026, 8, 8, 14, 30, 0, 0, time.UTC)
+	legacy := DailyLog{Date: "2026-08-08", Entries: []Entry{
+		{Id: "manual", Project: "devlog", Description: "manual", CreatedAt: created},
+		{Id: "random-old-id", Project: "devlog", Description: "imported", Source: "github:commit:abc", CreatedAt: created},
+	}}
+	if err := SaveDailyLog(filepath.Join(legacyEntries, "2026-08-08.json"), legacy); err != nil {
+		t.Fatal(err)
+	}
+	summary := []byte("---\ndate: 2026-08-08\nstyle: concise\nprojects: devlog\n---\n- done\n")
+	if err := os.WriteFile(filepath.Join(legacySummaries, "2026-08-08.md"), summary, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := NewRepository(dataRoot, configRoot)
+	result, err := repo.EnsureLayout()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.MigratedEntries != 2 || result.MigratedSummaries != 1 || result.BackupPath == "" {
+		t.Fatalf("unexpected migration result: %+v", result)
+	}
+	entries, err := repo.Entries(date)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+	if entries[1].Source == "github:commit:abc" && entries[1].Id != EntryID(entries[1].Source) {
+		t.Fatalf("imported entry ID is not deterministic: %s", entries[1].Id)
+	}
+	if _, err := os.Stat(filepath.Join(result.BackupPath, "entries", "2026-08-08.json")); err != nil {
+		t.Fatalf("legacy backup missing: %v", err)
+	}
+	second, err := repo.EnsureLayout()
+	if err != nil || !second.AlreadyCurrent {
+		t.Fatalf("second migration was not idempotent: %+v, %v", second, err)
+	}
+}
+
+func TestRepositoryDeduplicatesExternalSources(t *testing.T) {
+	root := t.TempDir()
+	repo := NewRepository(filepath.Join(root, "data"), root)
+	if _, err := repo.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	date := time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC)
+	now := time.Now().UTC()
+	first := Entry{Id: EntryID("github:commit:abc"), Source: "github:commit:abc", CreatedAt: now}
+	second := Entry{Id: "different", Source: first.Source, CreatedAt: now.Add(time.Second)}
+	added, err := repo.AddEntries(date, []Entry{first, second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(added) != 1 {
+		t.Fatalf("added %d entries, want 1", len(added))
+	}
+}
+
+func TestSummaryMetadataRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	repo := NewRepository(filepath.Join(root, "data"), root)
+	if _, err := repo.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	date := time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC)
+	summary := Summary{Date: date, Style: "concise", Content: "- done", AIGenerated: true}
+	if err := repo.SaveSummary(summary); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := repo.LoadSummary(date)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.GeneratedAt.IsZero() || loaded.DeviceID == "" || !loaded.AIGenerated {
+		t.Fatalf("summary metadata was not persisted: %+v", loaded)
+	}
+}
+
+func TestUnsafeDataRootDetection(t *testing.T) {
+	configRoot := filepath.Join(t.TempDir(), ".devlog")
+	if !unsafeDataRoot(configRoot, configRoot) {
+		t.Fatal("configuration root was accepted as the data root")
+	}
+	if !unsafeDataRoot(filepath.Dir(configRoot), configRoot) {
+		t.Fatal("a data root containing configuration was accepted")
+	}
+	if unsafeDataRoot(filepath.Join(configRoot, "data"), configRoot) {
+		t.Fatal("dedicated data directory was rejected")
+	}
+}
+
+func TestEntryIDsCannotEscapeDataDirectory(t *testing.T) {
+	root := t.TempDir()
+	repo := NewRepository(filepath.Join(root, "data"), root)
+	if _, err := repo.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	date := time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC)
+	added, err := repo.AddEntries(date, []Entry{{Id: "../../outside", CreatedAt: time.Now().UTC()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(added) != 1 || added[0].Id == "../../outside" {
+		t.Fatalf("unsafe entry ID was not normalized: %+v", added)
+	}
+	if _, err := os.Stat(filepath.Join(root, "outside.json")); !os.IsNotExist(err) {
+		t.Fatalf("entry escaped data directory: %v", err)
+	}
+}

--- a/internal/store/repository_test.go
+++ b/internal/store/repository_test.go
@@ -129,3 +129,44 @@ func TestEntryIDsCannotEscapeDataDirectory(t *testing.T) {
 		t.Fatalf("entry escaped data directory: %v", err)
 	}
 }
+
+func TestRepositoryLockBlocksUntilReleased(t *testing.T) {
+	root := t.TempDir()
+	repo := NewRepository(filepath.Join(root, "data"), root)
+	firstUnlock, err := repo.Lock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	acquired := make(chan func(), 1)
+	errs := make(chan error, 1)
+	go func() {
+		unlock, err := repo.Lock()
+		if err != nil {
+			errs <- err
+			return
+		}
+		acquired <- unlock
+	}()
+
+	select {
+	case unlock := <-acquired:
+		unlock()
+		firstUnlock()
+		t.Fatal("second lock was acquired before the first was released")
+	case err := <-errs:
+		firstUnlock()
+		t.Fatal(err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	firstUnlock()
+	select {
+	case unlock := <-acquired:
+		unlock()
+	case err := <-errs:
+		t.Fatal(err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("second lock did not acquire after release")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -23,6 +23,9 @@ type Entry struct {
 	Description string    `json:"description"`
 	Tags        []string  `json:"tags"`
 	CreatedAt   time.Time `json:"createdAt"`
+	// Source identifies the external origin of an entry (e.g. "github:commit:<sha>"),
+	// used to keep repeated syncs idempotent. Empty for manually added entries.
+	Source      string    `json:"source,omitempty"`
 }
 
 type Summary struct {
@@ -149,6 +152,8 @@ func Init() error {
 	viper.Set("llm.provider", "openrouter")
 	viper.Set("llm.model", "openai/gpt-oss-120b:free")
 	viper.Set("llm.apiKeyEnvVar", "OPENROUTER_API_KEY")
+	viper.Set("github.username", "")
+	viper.Set("github.tokenEnvVar", "GITHUB_TOKEN")
 
 	if err := viper.SafeWriteConfig(); err != nil {
 		return fmt.Errorf("fatal error writing config file: %w", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,33 +18,40 @@ type DailyLog struct {
 }
 
 type Entry struct {
-	Id          string    `json:"id"`
-	Project     string    `json:"project"`
-	Description string    `json:"description"`
-	Tags        []string  `json:"tags"`
-	CreatedAt   time.Time `json:"createdAt"`
+	Id          string     `json:"id"`
+	Project     string     `json:"project"`
+	Description string     `json:"description"`
+	Tags        []string   `json:"tags"`
+	CreatedAt   time.Time  `json:"createdAt"`
+	UpdatedAt   time.Time  `json:"updatedAt,omitempty"`
+	DeletedAt   *time.Time `json:"deletedAt,omitempty"`
 	// Source identifies the external origin of an entry (e.g. "github:commit:<sha>"),
 	// used to keep repeated syncs idempotent. Empty for manually added entries.
-	Source      string    `json:"source,omitempty"`
+	Source string `json:"source,omitempty"`
 }
 
 type Summary struct {
-	ID string // "2026-04-21", used as filename
-	Date time.Time
-	Projects []ProjectGroup
-	Style string
+	ID          string // "2026-04-21", used as filename
+	Date        time.Time
+	Projects    []ProjectGroup
+	Style       string
 	AIGenerated bool
-	Content string
+	GeneratedAt time.Time
+	DeviceID    string
+	Content     string
 }
 
 type SummaryMeta struct {
-    Date     string `yaml:"date"`
-    Style    string `yaml:"style"`
-    Projects string `yaml:"projects"`
+	Date        string    `yaml:"date"`
+	Style       string    `yaml:"style"`
+	Projects    string    `yaml:"projects"`
+	AIGenerated bool      `yaml:"aiGenerated,omitempty"`
+	GeneratedAt time.Time `yaml:"generatedAt,omitempty"`
+	DeviceID    string    `yaml:"deviceId,omitempty"`
 }
 
 type ProjectGroup struct {
-	Name string
+	Name    string
 	Entries []Entry
 }
 
@@ -83,6 +90,10 @@ func LoadSummary(filePath string) (Summary, error) {
 		return Summary{}, fmt.Errorf("error reading summary file: %w", err)
 	}
 
+	return ParseSummary(data)
+}
+
+func ParseSummary(data []byte) (Summary, error) {
 	parts := strings.SplitN(string(data), "---", 3)
 	if len(parts) < 3 {
 		return Summary{}, fmt.Errorf("invalid summary file: missing frontmatter")
@@ -106,29 +117,52 @@ func LoadSummary(filePath string) (Summary, error) {
 	}
 
 	return Summary{
-		ID:       meta.Date,
-		Date:     date,
-		Style:    meta.Style,
-		Projects: projects,
-		Content:  strings.TrimSpace(parts[2]),
+		ID:          meta.Date,
+		Date:        date,
+		Style:       meta.Style,
+		Projects:    projects,
+		AIGenerated: meta.AIGenerated,
+		GeneratedAt: meta.GeneratedAt,
+		DeviceID:    meta.DeviceID,
+		Content:     strings.TrimSpace(parts[2]),
 	}, nil
 }
 
 func SaveSummary(filePath string, summary Summary) error {
+	return saveSummaryAtomic(filePath, summary)
+}
+
+func saveSummaryAtomic(filePath string, summary Summary) error {
+	content := EncodeSummary(summary)
+	if err := atomicWrite(filePath, content, 0644); err != nil {
+		return fmt.Errorf("error writing summary file: %w", err)
+	}
+	return nil
+}
+
+func EncodeSummary(summary Summary) []byte {
 	projectNames := make([]string, len(summary.Projects))
 	for i, p := range summary.Projects {
 		projectNames[i] = p.Name
 	}
-	content := fmt.Sprintf("---\ndate: %s\nstyle: %s\nprojects: %s\n---\n%s\n",
+	content := fmt.Sprintf("---\ndate: %s\nstyle: %s\nprojects: %s\naiGenerated: %t\ngeneratedAt: %s\ndeviceId: %s\n---\n%s\n",
 		summary.Date.Format("2006-01-02"),
 		summary.Style,
 		strings.Join(projectNames, ", "),
+		summary.AIGenerated,
+		summary.GeneratedAt.UTC().Format(time.RFC3339Nano),
+		summary.DeviceID,
 		summary.Content,
 	)
-	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
-		return fmt.Errorf("error writing summary file: %w", err)
+	return []byte(content)
+}
+
+func marshalEntry(entry Entry) ([]byte, error) {
+	data, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	return append(data, '\n'), nil
 }
 
 func Init() error {
@@ -138,7 +172,7 @@ func Init() error {
 	}
 
 	if err := os.MkdirAll(path, 0755); err != nil {
-    	return fmt.Errorf("fatal error creating application directory: %w", err)
+		return fmt.Errorf("fatal error creating application directory: %w", err)
 	}
 
 	viper.AddConfigPath(path)
@@ -148,12 +182,16 @@ func Init() error {
 	viper.Set("defaults.project", "default")
 	viper.Set("defaults.style", "concise")
 	viper.Set("defaults.language", "pt-BR")
+	viper.Set("storage.path", "")
 	viper.Set("llm.enabled", false)
 	viper.Set("llm.provider", "openrouter")
 	viper.Set("llm.model", "openai/gpt-oss-120b:free")
 	viper.Set("llm.apiKeyEnvVar", "OPENROUTER_API_KEY")
 	viper.Set("github.username", "")
 	viper.Set("github.tokenEnvVar", "GITHUB_TOKEN")
+	viper.Set("remote.enabled", false)
+	viper.Set("remote.url", "")
+	viper.Set("remote.branch", "main")
 
 	if err := viper.SafeWriteConfig(); err != nil {
 		return fmt.Errorf("fatal error writing config file: %w", err)

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -1,0 +1,21 @@
+// Package templates embeds the style prompt templates used for
+// LLM-generated entries and summaries.
+package templates
+
+import (
+	"embed"
+	"fmt"
+)
+
+//go:embed *.md
+var files embed.FS
+
+// Get returns the prompt template for the given style
+// (concise, detailed, formal, impersonal).
+func Get(style string) (string, error) {
+	data, err := files.ReadFile(style + ".md")
+	if err != nil {
+		return "", fmt.Errorf("unknown style %q (available: concise, detailed, formal, impersonal)", style)
+	}
+	return string(data), nil
+}


### PR DESCRIPTION
## Summary

Adds GitHub activity sync, automatic scheduling, and Git-backed synchronization across machines.

## Changes

- Import GitHub commits, authored PRs, merged PRs, and reviews with `devlog sync`
- Add optional LLM polishing for synced entries and AI-generated summaries
- Support OpenRouter, OpenAI, DeepSeek, and custom OpenAI-compatible endpoints
- Add daily scheduling through macOS `launchd` and Linux cron
- Add protected environment-file support for scheduled credentials
- Add `devlog remote` commands for Git-based multi-machine sync
- Resolve entry and summary conflicts deterministically
- Migrate legacy daily JSON logs to conflict-resistant per-entry files
- Preserve migration backups and support explicit `devlog migrate`
- Restore Windows builds with platform-specific file locking
- Add tests and CI coverage for Linux and Windows

## Compatibility

Previously created entries and summaries are migrated automatically on first use and backed up under `~/.devlog/backups/`. No existing data is intentionally deleted.

## Verification

- go test ./...
- go build ./...
- GOOS=windows GOARCH=amd64 go build ./...